### PR TITLE
Make output of IP addresses of repeaters/peers configurable

### DIFF
--- a/dashboard/config.inc.php
+++ b/dashboard/config.inc.php
@@ -1,0 +1,5 @@
+<?php
+/* To suppres the output of IP addresses of Repeaters / Nodes set $showip to 0 
+ *  */
+$showip = 0;
+?>

--- a/dashboard/config.inc.php
+++ b/dashboard/config.inc.php
@@ -1,5 +1,5 @@
 <?php
-/* To suppres the output of IP addresses of Repeaters / Nodes set $showip to 0 
+/* To suppress the output of IP addresses of Repeaters / Nodes set $showip to 0 
  *  */
 $showip = 0;
 ?>

--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once("config.inc.php");
+
 $FILE = "/var/log/xlxd.xml";
 $PID  = "/var/log/xlxd.pid";
 

--- a/dashboard/pgs/repeaters.php
+++ b/dashboard/pgs/repeaters.php
@@ -53,8 +53,15 @@ for ($i=0;$i<$Reflector->NodeCount();$i++) {
    <td>'.date("d.m.Y H:i", $Reflector->Nodes[$i]->GetLastHeardTime()).'</td>
    <td>'.FormatSeconds(time()-$Reflector->Nodes[$i]->GetConnectTime()).' s</td>
    <td>'.$Reflector->Nodes[$i]->GetProtocol().'</td>
-   <td align="center">'.$Reflector->Nodes[$i]->GetLinkedModule().'</td>
-   <td>'.$Reflector->Nodes[$i]->GetIP().'</td>
+   <td align="center">'.$Reflector->Nodes[$i]->GetLinkedModule().'</td>';
+   echo '<td>';
+   if ($showip == 1) {
+      echo $Reflector->Nodes[$i]->GetIP();
+   } else {
+      echo 'n/a';
+   }
+   echo '</td>';
+   echo '
  </tr>';
    if ($i == 99) { $i = $Reflector->NodeCount()+1; }
 }


### PR DESCRIPTION
Hi Luc,

as stated by Klaus, DL5RFK I guess some people would like to suppress the output of IP addresses of nodes (private hotspots) on the dashboard page. I think this should be a configuration option. Here is my proposal :)

   vy73 de Florian DF2ET