### PR TITLE
Use predefined $(RM)

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -14,7 +14,7 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) $< -o $@
 
 clean:
-	rm *.o
+	$(RM) *.o
 
 install:
 	mkdir -p /xlxd

--- a/src/makefile
+++ b/src/makefile
@@ -4,6 +4,7 @@ LDFLAGS=-std=c++11 -pthread
 SOURCES=$(wildcard *.cpp)
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=xlxd
+RM=rm -f
 
 all: $(SOURCES) $(EXECUTABLE)
 


### PR DESCRIPTION
If you "make clean" when no .o files exist it results in an error:

--- 8< ---
user@host:~/dev/xlxd/src$ make clean
rm *.o
user@host:~/dev/xlxd/src$ make clean
rm *.o
rm: cannot remove ‘*.o’: No such file or directory
make: *** [clean] Error 1
--- 8< ---

It may be better to use $(RM) (which results in "rm -f" acutally) that does not fail if no .o files exists.