### PR TITLE
Link to Peers dashboards instead of base IP address

### DIFF
--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -52,7 +52,7 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
          $URL  = $XML->GetElement($Reflectors[$j], "dashboardurl");
       }
    }
-   if ($Result && $URL) {
+   if ($Result && (trim($URL) != "")) {
       echo '
    <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'" style="text-decoration:none;color:#000000;">'.$Name.'</a></td>';
    } else {

--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -2,18 +2,20 @@
 
 $Result = @fopen($CallingHome['ServerURL']."?do=GetReflectorList", "r");
 
-if (!$Result) die("HEUTE GIBTS KEIN BROT");
-
 $INPUT = "";
-while (!feof ($Result)) {
+
+if ($Result) {
+
+   while (!feof ($Result)) {
        $INPUT .= fgets ($Result, 1024);
+   }
+
+   $XML = new ParseXML();
+   $Reflectorlist = $XML->GetElement($INPUT, "reflectorlist");
+   $Reflectors    = $XML->GetAllElements($Reflectorlist, "reflector");
 }
+
 fclose($Result);
-
-$XML = new ParseXML();
-$Reflectorlist = $XML->GetElement($INPUT, "reflectorlist");
-$Reflectors    = $XML->GetAllElements($Reflectorlist, "reflector");
-
 ?>
 <table class="listingtable">
  <tr>
@@ -50,7 +52,7 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
          $URL  = $XML->GetElement($Reflectors[$j], "dashboardurl");
       }
    }
-   if ($URL) {
+   if ($Result && $URL) {
       echo '
    <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'" style="text-decoration:none;color:#000000;">'.$Name.'</a></td>';
    } else {

--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -52,7 +52,7 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
    }
    if ($URL) {
       echo '
-   <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'">'.$Name.'</a></td>';
+   <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'" style="text-decoration:none;color:#000000;">'.$Name.'</a></td>';
    } else {
       echo '
    <td>'.$Name.'</td>';

--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -37,11 +37,11 @@ $odd = "";
 $Reflector->LoadFlags();
 
 for ($i=0;$i<$Reflector->PeerCount();$i++) {
-         
+
    if ($odd == "#FFFFFF") { $odd = "#F1FAFA"; } else { $odd = "#FFFFFF"; }
- 
+
    echo '
-  <tr height="30" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
+   <tr height="30" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
    <td align="center">'.($i+1).'</td>';
    $Name = $Reflector->Peers[$i]->GetCallSign();
    for ($j=1;$j<count($Reflectors);$j++) {
@@ -75,6 +75,6 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
    if ($i == $PageOptions['PeerPage']['LimitTo']) { $i = $Reflector->PeerCount()+1; }
 }
 
-?> 
- 
+?>
+
 </table>

--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -44,14 +44,21 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
    <tr height="30" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
    <td align="center">'.($i+1).'</td>';
    $Name = $Reflector->Peers[$i]->GetCallSign();
+   $URL = '';
    for ($j=1;$j<count($Reflectors);$j++) {
       if ($Name === $XML->GetElement($Reflectors[$j], "name")) {
          $URL  = $XML->GetElement($Reflectors[$j], "dashboardurl");
          break;
       }
    }
+   if ($URL) {
+      echo '
+   <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'">'.$Name.'</a></td>'
+   } else {
+      echo '
+   <td>'.$Name.'</td>'
+   }
    echo '
-   <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'">'.$Name.'</a></td>
    <td>'.date("d.m.Y H:i", $Reflector->Peers[$i]->GetLastHeardTime()).'</td>
    <td>'.FormatSeconds(time()-$Reflector->Peers[$i]->GetConnectTime()).' s</td>
    <td align="center">'.$Reflector->Peers[$i]->GetProtocol().'</td>

--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -65,7 +65,7 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
             case 'ShowLast1ByteOfIP'      : echo $PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$Bytes[3]; break;
             case 'ShowLast2ByteOfIP'      : echo $PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$Bytes[2].'.'.$Bytes[3]; break;
             case 'ShowLast3ByteOfIP'      : echo $PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$Bytes[1].'.'.$Bytes[2].'.'.$Bytes[3]; break;
-            default                       : echo '<a href="http://'.$Reflector->Peers[$i]->GetIP().'" target="_blank" style="text-decoration:none;color:#000000;">'.$Reflector->Peers[$i]->GetIP().'</a>';
+            default                       : echo $Reflector->Peers[$i]->GetIP();
          }
       }
       echo '</td>';

--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -48,7 +48,6 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
    for ($j=1;$j<count($Reflectors);$j++) {
       if ($Name === $XML->GetElement($Reflectors[$j], "name")) {
          $URL  = $XML->GetElement($Reflectors[$j], "dashboardurl");
-         break;
       }
    }
    if ($URL) {

--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -1,3 +1,20 @@
+<?php
+
+$Result = @fopen($CallingHome['ServerURL']."?do=GetReflectorList", "r");
+
+if (!$Result) die("HEUTE GIBTS KEIN BROT");
+
+$INPUT = "";
+while (!feof ($Result)) {
+       $INPUT .= fgets ($Result, 1024);
+}
+fclose($Result);
+
+$XML = new ParseXML();
+$Reflectorlist = $XML->GetElement($INPUT, "reflectorlist");
+$Reflectors    = $XML->GetAllElements($Reflectorlist, "reflector");
+
+?>
 <table class="listingtable">
  <tr>   
    <th width="25">#</th>
@@ -25,8 +42,16 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
  
    echo '
   <tr height="30" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
-   <td align="center">'.($i+1).'</td>
-   <td>'.$Reflector->Peers[$i]->GetCallSign().'</td>
+   <td align="center">'.($i+1).'</td>';
+   $Name = $Reflector->Peers[$i]->GetCallSign();
+   for ($j=1;$j<count($Reflectors);$j++) {
+      if ($Name === $XML->GetElement($Reflectors[$j], "name")) {
+         $URL  = $XML->GetElement($Reflectors[$j], "dashboardurl");
+         break;
+      }
+   }
+   echo '
+   <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'">'.$Name.'</a></td>
    <td>'.date("d.m.Y H:i", $Reflector->Peers[$i]->GetLastHeardTime()).'</td>
    <td>'.FormatSeconds(time()-$Reflector->Peers[$i]->GetConnectTime()).' s</td>
    <td align="center">'.$Reflector->Peers[$i]->GetProtocol().'</td>

--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -16,7 +16,7 @@ $Reflectors    = $XML->GetAllElements($Reflectorlist, "reflector");
 
 ?>
 <table class="listingtable">
- <tr>   
+ <tr>
    <th width="25">#</th>
    <th width="100">XLX Peer</th>
    <th width="154">Last Heard</th>

--- a/dashboard/pgs/peers.php
+++ b/dashboard/pgs/peers.php
@@ -53,10 +53,10 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
    }
    if ($URL) {
       echo '
-   <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'">'.$Name.'</a></td>'
+   <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'">'.$Name.'</a></td>';
    } else {
       echo '
-   <td>'.$Name.'</td>'
+   <td>'.$Name.'</td>';
    }
    echo '
    <td>'.date("d.m.Y H:i", $Reflector->Peers[$i]->GetLastHeardTime()).'</td>


### PR DESCRIPTION
If the IP addresses on the peers page are not hidden they contain a hyper link. This link is not pointing to the dashboard in every case. For XLX518 for example the dashboard is reachable via a sub domain. 
So instead of pointing to the IP address it is more helpful to get the dashboard URL from the XLX API server. This patch is intended to do this.