### PR TITLE
Prevent sending queued packets back to the originator

### DIFF
--- a/src/cdcsprotocol.h
+++ b/src/cdcsprotocol.h
@@ -66,7 +66,7 @@ protected:
     bool IsValidConnectPacket(const CBuffer &, CCallsign *, char *);
     bool IsValidDisconnectPacket(const CBuffer &, CCallsign *);
     bool IsValidKeepAlivePacket(const CBuffer &, CCallsign *);
-    bool IsValidDvPacket(const CBuffer &, CDvHeaderPacket **, CDvFramePacket **);
+    bool IsValidDvPacket(const CBuffer &, CIp &, CDvHeaderPacket **, CDvFramePacket **);
     bool IsIgnorePacket(const CBuffer &);
     
     // packet encoding helpers

--- a/src/cdextraprotocol.h
+++ b/src/cdextraprotocol.h
@@ -84,9 +84,9 @@ protected:
     bool                IsValidConnectPacket(const CBuffer &, CCallsign *, char *, int *);
     bool                IsValidDisconnectPacket(const CBuffer &, CCallsign *);
     bool                IsValidKeepAlivePacket(const CBuffer &, CCallsign *);
-    CDvHeaderPacket     *IsValidDvHeaderPacket(const CBuffer &);
-    CDvFramePacket      *IsValidDvFramePacket(const CBuffer &);
-    CDvLastFramePacket  *IsValidDvLastFramePacket(const CBuffer &);
+    CDvHeaderPacket     *IsValidDvHeaderPacket(const CBuffer &, CIp &);
+    CDvFramePacket      *IsValidDvFramePacket(const CBuffer &, CIp &);
+    CDvLastFramePacket  *IsValidDvLastFramePacket(const CBuffer &, CIp &);
     
     // packet encoding helpers
     void                EncodeKeepAlivePacket(CBuffer *);

--- a/src/cdplusprotocol.h
+++ b/src/cdplusprotocol.h
@@ -70,9 +70,9 @@ protected:
     bool                IsValidLoginPacket(const CBuffer &, CCallsign *);
     bool                IsValidDisconnectPacket(const CBuffer &);
     bool                IsValidKeepAlivePacket(const CBuffer &);
-    CDvHeaderPacket     *IsValidDvHeaderPacket(const CBuffer &);
-    CDvFramePacket      *IsValidDvFramePacket(const CBuffer &);
-    CDvLastFramePacket  *IsValidDvLastFramePacket(const CBuffer &);
+    CDvHeaderPacket     *IsValidDvHeaderPacket(const CBuffer &, CIp &);
+    CDvFramePacket      *IsValidDvFramePacket(const CBuffer &, CIp &);
+    CDvLastFramePacket  *IsValidDvLastFramePacket(const CBuffer &, CIp &);
     
     // packet encoding helpers
     void                EncodeKeepAlivePacket(CBuffer *);

--- a/src/cdvframepacket.cpp
+++ b/src/cdvframepacket.cpp
@@ -37,8 +37,8 @@ CDvFramePacket::CDvFramePacket()
     ::memset(m_uiDvData, 0, sizeof(m_uiDvData));
 }
 
-CDvFramePacket::CDvFramePacket(const struct dstar_dvframe *dvframe, uint16 sid, uint8 pid)
-    : CPacket(sid, pid)
+CDvFramePacket::CDvFramePacket(const CClient *org, const struct dstar_dvframe *dvframe, uint16 sid, uint8 pid)
+    : CPacket(org, sid, pid)
 {
     ::memcpy(m_uiAmbe, dvframe->AMBE, sizeof(m_uiAmbe));
     ::memcpy(m_uiDvData, dvframe->DVDATA, sizeof(m_uiDvData));

--- a/src/cdvframepacket.h
+++ b/src/cdvframepacket.h
@@ -49,7 +49,7 @@ class CDvFramePacket : public CPacket
 public:
     // constructor
     CDvFramePacket();
-    CDvFramePacket(const struct dstar_dvframe *, uint16 = 0, uint8 = 0);
+    CDvFramePacket(const CClient *, const struct dstar_dvframe *, uint16 = 0, uint8 = 0);
     CDvFramePacket(const CDvFramePacket &);
     
     // destructor

--- a/src/cdvheaderpacket.cpp
+++ b/src/cdvheaderpacket.cpp
@@ -38,8 +38,8 @@ CDvHeaderPacket::CDvHeaderPacket()
     m_uiCrc = 0;
 }
 
-CDvHeaderPacket::CDvHeaderPacket(const struct dstar_header *buffer, uint16 sid, uint8 pid)
-    : CPacket(sid, pid)
+CDvHeaderPacket::CDvHeaderPacket(const CClient *org, const struct dstar_header *buffer, uint16 sid, uint8 pid)
+    : CPacket(org, sid, pid)
 {
     m_uiFlag1 = buffer->Flag1;
     m_uiFlag2 = buffer->Flag2;

--- a/src/cdvheaderpacket.h
+++ b/src/cdvheaderpacket.h
@@ -61,7 +61,7 @@ class CDvHeaderPacket : public CPacket
 public:
     // constructor
     CDvHeaderPacket();
-    CDvHeaderPacket(const struct dstar_header *, uint16 = 0, uint8 = 0);
+    CDvHeaderPacket(const CClient *, const struct dstar_header *, uint16 = 0, uint8 = 0);
     CDvHeaderPacket(const CDvHeaderPacket &);
     
     // destructor

--- a/src/cdvlastframepacket.cpp
+++ b/src/cdvlastframepacket.cpp
@@ -33,8 +33,8 @@ CDvLastFramePacket::CDvLastFramePacket()
 {
 }
 
-CDvLastFramePacket::CDvLastFramePacket(const struct dstar_dvframe *DvFrame, uint16 sid, uint8 pid)
-    : CDvFramePacket(DvFrame, sid, pid)
+CDvLastFramePacket::CDvLastFramePacket(const CClient *org, const struct dstar_dvframe *DvFrame, uint16 sid, uint8 pid)
+    : CDvFramePacket(org, DvFrame, sid, pid)
 {
 }
 

--- a/src/cdvlastframepacket.h
+++ b/src/cdvlastframepacket.h
@@ -40,7 +40,7 @@ class CDvLastFramePacket : public CDvFramePacket
 public:
     // constructor
     CDvLastFramePacket();
-    CDvLastFramePacket(const struct dstar_dvframe *, uint16 = 0, uint8 = 0);
+    CDvLastFramePacket(const CClient *, const struct dstar_dvframe *, uint16 = 0, uint8 = 0);
     CDvLastFramePacket(const CDvLastFramePacket &);
     
     // destructor

--- a/src/cpacket.cpp
+++ b/src/cpacket.cpp
@@ -34,14 +34,16 @@ CPacket::CPacket()
     m_uiPacketId = 0;
     m_uiModuleId = ' ';
     m_uiOriginId = ORIGIN_LOCAL;
+    m_OriginClient = NULL;
 };
 
-CPacket::CPacket(uint16 sid, uint8 pid)
+CPacket::CPacket(const CClient *org, uint16 sid, uint8 pid)
 {
     m_uiStreamId = sid;
     m_uiPacketId = pid;
     m_uiModuleId = ' ';
     m_uiOriginId = ORIGIN_LOCAL;
+    m_OriginClient = org;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cpacket.h
+++ b/src/cpacket.h
@@ -35,12 +35,14 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 // class
 
+class CClient;
+
 class CPacket
 {
 public:
     // constructor
     CPacket();
-    CPacket(uint16 sid, uint8 pid);
+    CPacket(const CClient *, uint16 sid, uint8 pid);
     
     // destructor
     virtual ~CPacket() {};
@@ -49,21 +51,22 @@ public:
     virtual CPacket *Duplicate(void) const;
     
     // identity
-    virtual bool IsDvHeader(void) const     { return false; }
-    virtual bool IsDvFrame(void) const      { return false; }
-    virtual bool IsLastPacket(void) const   { return false; }
+    virtual bool IsDvHeader(void) const           { return false; }
+    virtual bool IsDvFrame(void) const            { return false; }
+    virtual bool IsLastPacket(void) const         { return false; }
     
     // get
-    virtual bool IsValid(void) const        { return true; }
-    uint16 GetStreamId(void) const          { return m_uiStreamId; }
-    uint8  GetPacketId(void) const          { return m_uiPacketId; }
-    uint8  GetModuleId(void) const          { return m_uiModuleId; }
-    bool   IsLocalOrigin(void) const        { return (m_uiOriginId == ORIGIN_LOCAL); }
+    virtual bool IsValid(void) const              { return true; }
+    uint16 GetStreamId(void) const                { return m_uiStreamId; }
+    uint8  GetPacketId(void) const                { return m_uiPacketId; }
+    uint8  GetModuleId(void) const                { return m_uiModuleId; }
+    const CClient * GetOriginClient(void) const   { return m_OriginClient; }
+    bool   IsLocalOrigin(void) const              { return (m_uiOriginId == ORIGIN_LOCAL); }
     
     // set
-    void SetModuleId(uint8 uiId)            { m_uiModuleId = uiId; }
-    void SetLocalOrigin(void)               { m_uiOriginId = ORIGIN_LOCAL; }
-    void SetRemotePeerOrigin(void)          { m_uiOriginId = ORIGIN_PEER; }
+    void SetModuleId(uint8 uiId)                  { m_uiModuleId = uiId; }
+    void SetLocalOrigin(void)                     { m_uiOriginId = ORIGIN_LOCAL; }
+    void SetRemotePeerOrigin(void)                { m_uiOriginId = ORIGIN_PEER; }
 
 protected:
     // data
@@ -71,6 +74,7 @@ protected:
     uint8   m_uiPacketId;
     uint8   m_uiModuleId;
     uint8   m_uiOriginId;
+    const CClient * m_OriginClient;
 };
 
 

--- a/src/cxlxprotocol.cpp
+++ b/src/cxlxprotocol.cpp
@@ -74,14 +74,14 @@ void CXlxProtocol::Task(void)
     if ( m_Socket.Receive(&Buffer, &Ip, 20) != -1 )
     {
         // crack the packet
-        if ( (Frame = IsValidDvFramePacket(Buffer)) != NULL )
+        if ( (Frame = IsValidDvFramePacket(Buffer, Ip)) != NULL )
         {
             //std::cout << "XLX (DExtra) DV frame"  << std::endl;
             
             // handle it
             OnDvFramePacketIn(Frame);
         }
-        else if ( (Header = IsValidDvHeaderPacket(Buffer)) != NULL )
+        else if ( (Header = IsValidDvHeaderPacket(Buffer, Ip)) != NULL )
         {
             //std::cout << "XLX (DExtra) DV header:"  << std::endl << *Header << std::endl;
             
@@ -96,7 +96,7 @@ void CXlxProtocol::Task(void)
                 delete Header;
             }
         }
-        else if ( (LastFrame = IsValidDvLastFramePacket(Buffer)) != NULL )
+        else if ( (LastFrame = IsValidDvLastFramePacket(Buffer, Ip)) != NULL )
         {
             //std::cout << "XLX (DExtra) DV last frame" << std::endl;
             
@@ -218,9 +218,9 @@ void CXlxProtocol::HandleQueue(void)
                 CClient *client = NULL;
                 while ( (client = clients->FindNextClient(PROTOCOL_XLX, &index)) != NULL )
                 {
-                    // is this client busy ?
+                    // is this client busy or the originator ?
                     // here check that origin module of the stream is listed in client xlx
-                    if ( !client->IsAMaster() && client->HasThisReflectorModule(packet->GetModuleId()) )
+                    if ( !client->IsAMaster() && client->HasThisReflectorModule(packet->GetModuleId()) && (client != packet->GetOriginClient()) )
                     {
                         // no, send the packet
                         m_Socket.Send(buffer, client->GetIp());


### PR DESCRIPTION
Add a originator identification by client pointer to packets. Use this
info to filter outgoing packets so the originator does not get its own
packets.
