### PR TITLE
Use protocol names instead of numbers in logs

### DIFF
--- a/src/cclients.cpp
+++ b/src/cclients.cpp
@@ -85,7 +85,7 @@ void CClients::AddClient(CClient *client)
         // and append
         m_Clients.push_back(client);
         std::cout << "New client " << client->GetCallsign() << " at " << client->GetIp() 
-                  << " added with protocol " << client->GetProtocol()
+                  << " added with protocol " << client->GetProtocolName()
                   << " on module " << client->GetReflectorModule() << std::endl;
         // notify
         g_Reflector.OnClientsChanged();
@@ -106,7 +106,7 @@ void CClients::RemoveClient(CClient *client)
             {
                 // remove it
                 std::cout << "Client " << m_Clients[i]->GetCallsign() << " at " << m_Clients[i]->GetIp()
-                          << " removed with protocol " << client->GetProtocol()
+                          << " removed with protocol " << client->GetProtocolName()
                           << " on module " << client->GetReflectorModule() << std::endl;
                 delete m_Clients[i];
                 m_Clients.erase(m_Clients.begin()+i);

--- a/src/cdextraclient.h
+++ b/src/cdextraclient.h
@@ -48,7 +48,7 @@ public:
     // identity
     int GetProtocol(void) const                 { return PROTOCOL_DEXTRA; }
     int GetProtocolRevision(void) const         { return m_ProtRev; }
-    const char *GetProtocolName(void) const     { return "Dextra"; }
+    const char *GetProtocolName(void) const     { return "DExtra"; }
     bool IsNode(void) const                     { return true; }
     
     // status

--- a/src/cdplusclient.h
+++ b/src/cdplusclient.h
@@ -47,7 +47,7 @@ public:
     
     // identity
     int GetProtocol(void) const                 { return PROTOCOL_DPLUS; }
-    const char *GetProtocolName(void) const     { return "Dplus"; }
+    const char *GetProtocolName(void) const     { return "DPlus"; }
     bool IsNode(void) const                     { return true; }
     bool IsDextraDongle(void) const             { return m_bDextraDongle; }
     void SetDextraDongle(void)                  { m_bDextraDongle = true; }

--- a/src/cpeers.cpp
+++ b/src/cpeers.cpp
@@ -85,7 +85,7 @@ void CPeers::AddPeer(CPeer *peer)
         // append peer to reflector peer list
         m_Peers.push_back(peer);
         std::cout << "New peer " << peer->GetCallsign() << " at " << peer->GetIp()
-                  << " added with protocol " << peer->GetProtocol()  << std::endl;
+                  << " added with protocol " << peer->GetProtocolName()  << std::endl;
         // and append all peer's client to reflector client list
         // it is double lock safe to lock Clients list after Peers list
         CClients *clients = g_Reflector.GetClients();


### PR DESCRIPTION
I replaces GetProtocol with GetProtocolName in order to find the protocol name in the logs instead of just the plain number. I also renamed "Dplus" to "DPlus" and "Dextra" to "DExtra" in order to comply with what is commonly used.