### PR TITLE
Link reflector

### DIFF
--- a/dashboard/pgs/users.php
+++ b/dashboard/pgs/users.php
@@ -1,5 +1,22 @@
 <?php
 
+$Result = @fopen($CallingHome['ServerURL']."?do=GetReflectorList", "r");
+
+$INPUT = "";
+
+if ($Result) {
+
+   while (!feof ($Result)) {
+       $INPUT .= fgets ($Result, 1024);
+   }
+
+   $XML = new ParseXML();
+   $Reflectorlist = $XML->GetElement($INPUT, "reflectorlist");
+   $Reflectors    = $XML->GetAllElements($Reflectorlist, "reflector");
+}
+
+fclose($Result);
+
 if (!isset($_SESSION['FilterCallSign'])) {
    $_SESSION['FilterCallSign'] = null;
 }
@@ -144,8 +161,20 @@ for ($i=0;$i<$Reflector->StationCount();$i++) {
    <td width="60">'.$Reflector->Stations[$i]->GetSuffix().'</td>
    <td width="50" align="center"><a href="http://www.aprs.fi/'.$Reflector->Stations[$i]->GetCallsignOnly().'" class="pl" target="_blank"><img src="./img/sat.png" /></a></td>
    <td width="150">'.$Reflector->Stations[$i]->GetVia();
-      if ($Reflector->Stations[$i]->GetPeer() != $Reflector->GetReflectorName()) {
-         echo ' / '.$Reflector->Stations[$i]->GetPeer();
+      $Peer = '';
+      $URL = '';
+      $Peer = $Reflector->Stations[$i]->GetPeer();
+      if ($Peer != $Reflector->GetReflectorName()) {
+         for ($j=1;$j<count($Reflectors);$j++) {
+            if ($Peer === $XML->GetElement($Reflectors[$j], "name")) {
+               $URL  = $XML->GetElement($Reflectors[$j], "dashboardurl");
+            }
+         }
+         if ($Result && (trim($URL) != "")) {
+            echo ' / <a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Peer.'" style="text-decoration:none;color:#000000;">'.$Reflector->Stations[$i]->GetPeer().'</a>';
+         } else {
+            echo ' / '.$Reflector->Stations[$i]->GetPeer();
+         }
       }
       echo '</td>
    <td width="150">'.@date("d.m.Y H:i", $Reflector->Stations[$i]->GetLastHeardTime()).'</td>

--- a/dashboard/pgs/users.php
+++ b/dashboard/pgs/users.php
@@ -171,9 +171,9 @@ for ($i=0;$i<$Reflector->StationCount();$i++) {
             }
          }
          if ($Result && (trim($URL) != "")) {
-            echo ' / <a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Peer.'" style="text-decoration:none;color:#000000;">'.$Reflector->Stations[$i]->GetPeer().'</a>';
+            echo ' / <a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Peer.'" style="text-decoration:none;color:#000000;">'.$Peer.'</a>';
          } else {
-            echo ' / '.$Reflector->Stations[$i]->GetPeer();
+            echo ' / '.$Peer;
          }
       }
       echo '</td>

--- a/dashboard2/pgs/peers.php
+++ b/dashboard2/pgs/peers.php
@@ -1,3 +1,23 @@
+<?php
+
+$Result = @fopen($CallingHome['ServerURL']."?do=GetReflectorList", "r");
+
+$INPUT = ""; 
+
+if ($Result) {
+
+      while (!feof ($Result)) {
+                $INPUT .= fgets ($Result, 1024);
+                   }   
+
+         $XML = new ParseXML();
+         $Reflectorlist = $XML->GetElement($INPUT, "reflectorlist");
+            $Reflectors    = $XML->GetAllElements($Reflectorlist, "reflector");
+}
+
+fclose($Result);
+?>
+
 <table class="table table-striped table-hover">
    <tr class="table-center">
       <th class="col-md-1">#</th>
@@ -22,7 +42,22 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
          
    echo '
   <tr class="table-center">
-   <td>'.($i+1).'</td>
+   <td>'.($i+1).'</td>';
+   $Name = $Reflector->Peers[$i]->GetCallSign();
+   $URL = ''; 
+   for ($j=1;$j<count($Reflectors);$j++) {
+      if ($Name === $XML->GetElement($Reflectors[$j], "name")) {
+         $URL  = $XML->GetElement($Reflectors[$j], "dashboardurl");
+      }   
+   }   
+   if ($Result && (trim($URL) != "")) {
+      echo '
+   <td><a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Name.'">'.$Name.'</a></td>';
+   } else {
+      echo '
+   <td>'.$Name.'</td>';
+   }
+   echo '
    <td>'.$Reflector->Peers[$i]->GetCallSign().'</td>
    <td>'.date("d.m.Y H:i", $Reflector->Peers[$i]->GetLastHeardTime()).'</td>
    <td>'.FormatSeconds(time()-$Reflector->Peers[$i]->GetConnectTime()).' s</td>
@@ -37,7 +72,7 @@ for ($i=0;$i<$Reflector->PeerCount();$i++) {
             case 'ShowLast1ByteOfIP'      : echo $PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$Bytes[3]; break;
             case 'ShowLast2ByteOfIP'      : echo $PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$Bytes[2].'.'.$Bytes[3]; break;
             case 'ShowLast3ByteOfIP'      : echo $PageOptions['PeerPage']['MasqueradeCharacter'].'.'.$Bytes[1].'.'.$Bytes[2].'.'.$Bytes[3]; break;
-            default                       : echo '<a href="http://'.$Reflector->Peers[$i]->GetIP().'" target="_blank" style="text-decoration:none;color:#000000;">'.$Reflector->Peers[$i]->GetIP().'</a>';
+            default                       : echo $Reflector->Peers[$i]->GetIP();
          }
       }
       echo '</td>';

--- a/dashboard2/pgs/users.php
+++ b/dashboard2/pgs/users.php
@@ -1,3 +1,23 @@
+ <?php
+ 
+$Result = @fopen($CallingHome['ServerURL']."?do=GetReflectorList", "r");
+
+$INPUT = "";
+
+if ($Result) {
+
+   while (!feof ($Result)) {
+       $INPUT .= fgets ($Result, 1024);
+   }
+
+   $XML = new ParseXML();
+   $Reflectorlist = $XML->GetElement($INPUT, "reflectorlist");
+   $Reflectors    = $XML->GetAllElements($Reflectorlist, "reflector");
+}
+
+fclose($Result);
+?>
+
 <div class="row">
    <div class="col-md-9">
       <table class="table table-striped table-hover">
@@ -33,8 +53,20 @@ for ($i=0;$i<$Reflector->StationCount();$i++) {
    <td>'.$Reflector->Stations[$i]->GetSuffix().'</td>
    <td><a href="http://www.aprs.fi/'.$Reflector->Stations[$i]->GetCallsignOnly().'" class="pl" target="_blank"><img src="./img/sat.png" alt=""></a></td>
    <td>'.$Reflector->Stations[$i]->GetVia();
-   if ($Reflector->Stations[$i]->GetPeer() != $Reflector->GetReflectorName()) {
-      echo ' / '.$Reflector->Stations[$i]->GetPeer();
+   $Peer = '';
+   $URL = '';
+   $Peer = $Reflector->Stations[$i]->GetPeer();
+   if ($Peer != $Reflector->GetReflectorName()) {
+      for ($j=1;$j<count($Reflectors);$j++) {
+         if ($Peer === $XML->GetElement($Reflectors[$j], "name")) {
+            $URL  = $XML->GetElement($Reflectors[$j], "dashboardurl");
+         }
+      }
+      if ($Result && (trim($URL) != "")) {
+         echo ' / <a href="'.$URL.'" target="_blank" class="listinglink" title="Visit the Dashboard of&nbsp;'.$Peer.'">'.$Peer.'</a>';
+      } else {
+         echo ' / '.$Peer;
+      }
    }
    echo '</td>
    <td>'.@date("d.m.Y H:i", $Reflector->Stations[$i]->GetLastHeardTime()).'</td>


### PR DESCRIPTION
If stations come in via a second XLX reflector to ingress reflector is shown in the "Via" tab. This makes the via a link to the dashboard to save some clicks if you want to go to the dashboard of the ingress reflector immediately.