### PR TITLE
FT2xx driver is not needed for ambedtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.o
 xlxd
+ambed
+ambedtest

--- a/ambedtest/makefile
+++ b/ambedtest/makefile
@@ -8,7 +8,7 @@ EXECUTABLE=ambedtest
 all: $(SOURCES) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) -lftd2xx -Wl,-rpath,/usr/local/lib -o $@
+	$(CC) $(LDFLAGS) $(OBJECTS) -Wl,-rpath,/usr/local/lib -o $@
 
 .cpp.o:
 	$(CC) $(CFLAGS) $< -o $@


### PR DESCRIPTION
The FT2xx headers are not used in the code. So they should not be linked to by the makefile.