### PR TITLE
Remove double slash and add some carriage returns

### DIFF
--- a/src/cdmriddir.cpp
+++ b/src/cdmriddir.cpp
@@ -63,7 +63,7 @@ bool CDmridDir::RefreshContent(void)
     CBuffer buffer;
     
     // get file from xlxapi server
-    if ( (ok = HttpGet("xlxapi.rlx.lu", "/api/exportdmr.php", 80, &buffer)) )
+    if ( (ok = HttpGet("xlxapi.rlx.lu", "api/exportdmr.php", 80, &buffer)) )
     {
         // clear directory
         m_CallsignMap.clear();
@@ -207,7 +207,7 @@ bool CDmridDir::HttpGet(const char *hostname, const char *filename, int port, CB
             {
                 // send the GET request
                 char request[DMRID_HTTPGET_SIZEMAX];
-                ::sprintf(request, "GET /%s HTTP/1.0\nFrom: %s\nUser-Agent: xlxd\n\n",
+                ::sprintf(request, "GET /%s HTTP/1.0\r\nFrom: %s\r\nUser-Agent: xlxd\r\n\r\n",
                           filename, (const char *)g_Reflector.GetCallsign());
                 ::write(sock_id, request, strlen(request));
 


### PR DESCRIPTION
The current implementation of the API function to pull DMR IDs does not work. 
There is a double slash betweens hostname and path (not really a problem I guess) and
there are some carriage returns (CR aka. 0x0d) missing to separate lines in the HTTP protocol.
The latter results in an error message being generated by the API server.

![bildschirmfoto vom 2017-08-23 12-02-32](https://user-images.githubusercontent.com/7112907/29613427-3f184de8-8806-11e7-8b15-355a8a81ef50.png)
