### PR TITLE
Make "make clean" also remove the binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Please use the stable version listed above, we cannot support others.
 ```
 # git clone https://github.com/LX3JL/xlxd.git
 # cd xlxd/src/
-# make
 # make clean
+# make
 # make install
 ```
 

--- a/src/makefile
+++ b/src/makefile
@@ -14,7 +14,7 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) $< -o $@
 
 clean:
-	$(RM) *.o
+	$(RM) xlxd *.o
 
 install:
 	mkdir -p /xlxd


### PR DESCRIPTION
make clean does not remove the built binary. That can cause confusion in cases where the build process fails. In such case the binary is still there and one could use that by mistake.
I suppose "make clean" should also remove the binary from previous builds to make sure the newly built one is really new.