### PR TITLE
Add ambed binary to make clean

### DIFF
--- a/ambed/makefile
+++ b/ambed/makefile
@@ -14,9 +14,9 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) $< -o $@
 
 clean:
-	$(RM) *.o
+	$(RM) $(EXECUTABLE) *.o
 
 install:
 	mkdir -p /ambed
-	cp ./ambed /ambed/
+	cp $(EXECUTABLE) /ambed/
 	cp ./run /ambed/

--- a/ambed/readme
+++ b/ambed/readme
@@ -61,8 +61,8 @@ Follow FTDI provided documentation for installation and testing of the drivers.
 
 # git clone https://github.com/LX3JL/xlxd.git
 # cd xlxd/ambed/
-# make
 # make clean
+# make
 # make install
 
 3) configuring ambed startup script

--- a/ambedtest/makefile
+++ b/ambedtest/makefile
@@ -14,4 +14,4 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) $< -o $@
 
 clean:
-	$(RM) *.o
+	$(RM) $(EXECUTABLE) *.o

--- a/src/makefile
+++ b/src/makefile
@@ -14,11 +14,11 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) $< -o $@
 
 clean:
-	$(RM) xlxd *.o
+	$(RM) $(EXECUTABLE) *.o
 
 install:
 	mkdir -p /xlxd
-	cp ./xlxd /xlxd/
+	cp $(EXECUTABLE) /xlxd/
 	cp -i ../config/xlxd.blacklist /xlxd/
 	cp -i ../config/xlxd.whitelist /xlxd/
 	cp -i ../config/xlxd.interlink /xlxd/


### PR DESCRIPTION
Change makefile of ambed according to https://github.com/phl0/xlxd/commit/8a545b99c810d8be1b09eb237a2c6d404e4f76ef for xlxd.
Also made the makefiles a little more portable with use of variables for $(EXECUTABLE)