### PR TITLE
Fix .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.o
-xlxd
-ambed
-ambedtest
+src/xlxd
+ambed/ambed
+ambedtest/ambedtest


### PR DESCRIPTION
The current .gitignore is a little borken. It ignores whole directories instead of only the binaries.
This fixes it.