### PR TITLE
Change log messge when DMR IDs to be read from local file

### DIFF
--- a/src/cdmriddir.cpp
+++ b/src/cdmriddir.cpp
@@ -170,7 +170,7 @@ bool CDmridDir::RefreshContent(void)
     }
     
     // report
-    std::cout << "Read " << m_DmridMap.size() << " DMR id from online database " << std::endl;
+    std::cout << "Read " << m_DmridMap.size() << " DMR id from local file " << std::endl;
     
     // done
     return ok;

--- a/src/cdmriddir.cpp
+++ b/src/cdmriddir.cpp
@@ -104,7 +104,7 @@ bool CDmridDir::RefreshContent(void)
     }
     
     // report
-    std::cout << "Read " << m_DmridMap.size() << " DMR id from online database " << std::endl;
+    std::cout << "Read " << m_DmridMap.size() << " DMR IDs from online database " << std::endl;
     
     // done
     return ok;
@@ -170,7 +170,7 @@ bool CDmridDir::RefreshContent(void)
     }
     
     // report
-    std::cout << "Read " << m_DmridMap.size() << " DMR id from local file " << std::endl;
+    std::cout << "Read " << m_DmridMap.size() << " DMR IDs from local file " << std::endl;
     
     // done
     return ok;


### PR DESCRIPTION
Log message is the same independent if DMR IDs are read from local file or from online database.
I corrected this so that one can see if the IDs were read from local file or online database.