### PR TITLE
Redo changes of PR #29 previously overwritten with commit 83278d13

### DIFF
--- a/src/cclients.cpp
+++ b/src/cclients.cpp
@@ -85,7 +85,7 @@ void CClients::AddClient(CClient *client)
         // and append
         m_Clients.push_back(client);
         std::cout << "New client " << client->GetCallsign() << " at " << client->GetIp() 
-                  << " added with protocol " << client->GetProtocol();
+                  << " added with protocol " << client->GetProtocolName();
         if ( client->GetReflectorModule() != ' ' )
         {
             std::cout << " on module " << client->GetReflectorModule();
@@ -110,7 +110,7 @@ void CClients::RemoveClient(CClient *client)
             {
                 // remove it
                 std::cout << "Client " << m_Clients[i]->GetCallsign() << " at " << m_Clients[i]->GetIp()
-                          << " removed with protocol " << client->GetProtocol();
+                          << " removed with protocol " << client->GetProtocolName();
                 if ( client->GetReflectorModule() != ' ' )
                 {
                     std::cout << " on module " << client->GetReflectorModule();

--- a/src/cdextraclient.h
+++ b/src/cdextraclient.h
@@ -48,7 +48,7 @@ public:
     // identity
     int GetProtocol(void) const                 { return PROTOCOL_DEXTRA; }
     int GetProtocolRevision(void) const         { return m_ProtRev; }
-    const char *GetProtocolName(void) const     { return "Dextra"; }
+    const char *GetProtocolName(void) const     { return "DExtra"; }
     int GetCodec(void) const                    { return CODEC_AMBEPLUS; }
     bool IsNode(void) const                     { return true; }
     

--- a/src/cdplusclient.h
+++ b/src/cdplusclient.h
@@ -47,7 +47,7 @@ public:
     
     // identity
     int GetProtocol(void) const                 { return PROTOCOL_DPLUS; }
-    const char *GetProtocolName(void) const     { return "Dplus"; }
+    const char *GetProtocolName(void) const     { return "DPlus"; }
     int GetCodec(void) const                    { return CODEC_AMBEPLUS; }
     bool IsNode(void) const                     { return true; }
     bool IsDextraDongle(void) const             { return m_bDextraDongle; }

--- a/src/cpeers.cpp
+++ b/src/cpeers.cpp
@@ -85,7 +85,7 @@ void CPeers::AddPeer(CPeer *peer)
         // append peer to reflector peer list
         m_Peers.push_back(peer);
         std::cout << "New peer " << peer->GetCallsign() << " at " << peer->GetIp()
-                  << " added with protocol " << peer->GetProtocol()  << std::endl;
+                  << " added with protocol " << peer->GetProtocolName()  << std::endl;
         // and append all peer's client to reflector client list
         // it is double lock safe to lock Clients list after Peers list
         CClients *clients = g_Reflector.GetClients();


### PR DESCRIPTION
I have done some changes in https://github.com/LX3JL/xlxd/pull/29 that were merged into master branch with https://github.com/LX3JL/xlxd/commit/76dc7d1ecfc790d6d91a6e7cfc9579f3709c1687.

But these were overwritten with https://github.com/LX3JL/xlxd/commit/83278d13 (reported by @dg0tm).

I guess this was a mistake and would like to have that integrated again.