### PR TITLE
dashboard: avoid page scroll to top on reloads

### DIFF
--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -98,12 +98,8 @@ else {
       var PageRefresh;
       
       function ReloadPage() {
-         document.location.href = "./index.php';
-     if (isset($_GET['show'])) {
-        echo '?show='.$_GET['show'];
-     }
-     echo '";
-      }';
+         document.location.reload();
+      }
 
      if (!isset($_GET['show']) || (($_GET['show'] != 'liveircddb') && ($_GET['show'] != 'reflectors') && ($_GET['show'] != 'interlinks'))) {
          echo '

--- a/dashboard/pgs/users.php
+++ b/dashboard/pgs/users.php
@@ -36,6 +36,12 @@ if (isset($_POST['do'])) {
          
       }
    }
+   
+   //after process post request, redirect to avoid browser asking to resend data on page reload
+   $protocol = ( (!empty($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] !== 'off')) 
+     || ($_SERVER['SERVER_PORT'] == 443) ) ? 'https://' : 'http://';
+   header('Location: ' . $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF']);
+   exit;
 }
 
 if (isset($_GET['do'])) {


### PR DESCRIPTION
This is a small patch to dashboard pages to use location.reload() instead of location.href to try to keep page scroll position after auto page reloads, because it is very annoying to try to browse page with many users or long activity log and having it always scrolling to top every few seconds...

As downside it also fixes bug on traffic page where "iface" GET var would be lost on page reloads.