### PR TITLE
dashboard: avoid page scroll to top on reloads

### DIFF
--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -97,12 +97,19 @@ else {
    <script>
       var PageRefresh;
       
-      function ReloadPage() {
+      function ReloadPage() {';
+     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+       echo '
          document.location.href = "./index.php';
-     if (isset($_GET['show'])) {
-        echo '?show='.$_GET['show'];
+       if (isset($_GET['show'])) {
+         echo '?show='.$_GET['show'];
+       }
+       echo '";';
+     } else {
+       echo '
+         document.location.reload();';
      }
-     echo '";
+     echo '
       }';
 
      if (!isset($_GET['show']) || (($_GET['show'] != 'liveircddb') && ($_GET['show'] != 'reflectors') && ($_GET['show'] != 'interlinks'))) {

--- a/dashboard2/index.php
+++ b/dashboard2/index.php
@@ -107,6 +107,7 @@ if ($CallingHome['Active']) {
     if ($PageOptions['PageRefreshActive']) {
         echo '
    <script>
+      var PageRefresh;
 
       function ReloadPage() {';
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -125,10 +126,13 @@ if ($CallingHome['Active']) {
 
         if (!isset($_GET['show']) || (($_GET['show'] != 'liveircddb') && ($_GET['show'] != 'reflectors') && ($_GET['show'] != 'interlinks'))) {
             echo '
-      setTimeout(ReloadPage, ' . $PageOptions['PageRefreshDelay'] . ');';
+      PageRefresh = setTimeout(ReloadPage, ' . $PageOptions['PageRefreshDelay'] . ');';
         }
         echo '
 
+      function SuspendPageRefresh() {
+        clearTimeout(PageRefresh);
+      }
    </script>';
     }
     if (!isset($_GET['show'])) $_GET['show'] = "";

--- a/dashboard2/index.php
+++ b/dashboard2/index.php
@@ -108,12 +108,19 @@ if ($CallingHome['Active']) {
         echo '
    <script>
 
-      function ReloadPage() {
+      function ReloadPage() {';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+          echo '
          document.location.href = "./index.php';
-        if (isset($_GET['show'])) {
+          if (isset($_GET['show'])) {
             echo '?show=' . $_GET['show'];
+          }
+          echo '";';
+        } else {
+          echo '
+         document.location.reload();';
         }
-        echo '";
+        echo '
       }';
 
         if (!isset($_GET['show']) || (($_GET['show'] != 'liveircddb') && ($_GET['show'] != 'reflectors') && ($_GET['show'] != 'interlinks'))) {


### PR DESCRIPTION
This is a small patch to dashboard and dashboard2 pages to use location.reload() instead of location.href so that browsers keep page scroll position after auto page reloads, because it is very annoying to try to browse page with many users or long activity log and having it always scrolling to top every few seconds...
It inherently fixes bug on Traffic page where "iface" GET var would be lost on every page reloads.

Also fixed missing SuspendPageRefresh() on dashboard2, called to stop auto refresh while user is typing on callsign/module filtering input fields.