### PR TITLE
don't use location.reload() if there is a 'do' GET request

### DIFF
--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -98,7 +98,7 @@ else {
       var PageRefresh;
       
       function ReloadPage() {';
-     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+     if (($_SERVER['REQUEST_METHOD'] === 'POST') || isset($_GET['do'])) {
        echo '
          document.location.href = "./index.php';
        if (isset($_GET['show'])) {

--- a/dashboard2/index.php
+++ b/dashboard2/index.php
@@ -110,7 +110,7 @@ if ($CallingHome['Active']) {
       var PageRefresh;
 
       function ReloadPage() {';
-        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if (($_SERVER['REQUEST_METHOD'] === 'POST') || isset($_GET['do'])) {
           echo '
          document.location.href = "./index.php';
           if (isset($_GET['show'])) {


### PR DESCRIPTION
Small addition (to my last pr) to ensure the 'do' GET request are not processed multiple times on reloads... not critical as it is currently only used for 'resetfilter' and it causes no problem with it, however I still think it's better to fix it properly...