### PR TITLE
dashboard performance enhancement

### DIFF
--- a/dashboard/pgs/class.reflector.php
+++ b/dashboard/pgs/class.reflector.php
@@ -6,6 +6,7 @@ class xReflector {
    public $Stations                  = null;
    public $Peers                     = null;
    private $Flagarray                = null;
+   private $Flagarray_DXCC           = null;
    private $Flagfile                 = null;
    private $CallingHomeActive        = null;
    private $CallingHomeHash          = null;
@@ -125,6 +126,7 @@ class xReflector {
    public function LoadFlags() {
       if ($this->Flagfile != null) {
          $this->Flagarray = array();
+         $this->Flagarray_DXCC = array();
          $handle = fopen($this->Flagfile,"r");
          if ($handle) {
             $i = 0;
@@ -134,11 +136,12 @@ class xReflector {
          
                if (isset($tmp[0])) { $this->Flagarray[$i]['Country'] = $tmp[0]; } else { $this->Flagarray[$i]['Country'] = 'Undefined'; }
                if (isset($tmp[1])) { $this->Flagarray[$i]['ISO']     = $tmp[1]; } else { $this->Flagarray[$i]['ISO'] = "Undefined"; }
-               $this->Flagarray[$i]['DXCC']    = array();
+               //$this->Flagarray[$i]['DXCC']    = array();
                if (isset($tmp[2])) { 
                   $tmp2 = explode("-", $tmp[2]);
                   for ($j=0;$j<count($tmp2);$j++) {
-                     $this->Flagarray[$i]['DXCC'][] = $tmp2[$j];
+                     //$this->Flagarray[$i]['DXCC'][] = $tmp2[$j];
+                     $this->Flagarray_DXCC[ trim($tmp2[$j]) ] = $i;
                   }
                }
                $i++; 
@@ -256,25 +259,15 @@ class xReflector {
    
    public function GetFlag($Callsign) {
       $Image     = "";
-      $FoundFlag = false;
       $Letters = 4;
       $Name = "";
-      while (($Letters >= 2) && (!$FoundFlag)) {
-         $j = 0;
-         $Prefix = substr($Callsign, 0, $Letters);
-         while (($j < count($this->Flagarray)) && (!$FoundFlag)) {
-            
-            $z = 0;
-            while (($z < count($this->Flagarray[$j]['DXCC'])) && (!$FoundFlag)) {
-               if (trim($Prefix) == trim($this->Flagarray[$j]['DXCC'][$z])) {
-                  $Image = $this->Flagarray[$j]['ISO'];
-                  $Name = $this->Flagarray[$j]['Country'];
-                  $FoundFlag = true;
+      while ($Letters >= 2) {
+         $Prefix = substr(trim($Callsign), 0, $Letters);
+               if (isset($this->Flagarray_DXCC[$Prefix])) {
+                  $Image = $this->Flagarray[ $this->Flagarray_DXCC[$Prefix] ]['ISO'];
+                  $Name  = $this->Flagarray[ $this->Flagarray_DXCC[$Prefix] ]['Country'];
+                  break;
                }
-               $z++;
-            }
-            $j++;
-         }
          $Letters--;
       }
       return array(strtolower($Image), $Name);

--- a/dashboard2/pgs/class.reflector.php
+++ b/dashboard2/pgs/class.reflector.php
@@ -6,6 +6,7 @@ class xReflector {
    public $Stations                  = null;
    public $Peers                     = null;
    private $Flagarray                = null;
+   private $Flagarray_DXCC           = null;
    private $Flagfile                 = null;
    private $CallingHomeActive        = null;
    private $CallingHomeHash          = null;
@@ -125,6 +126,7 @@ class xReflector {
    public function LoadFlags() {
       if ($this->Flagfile != null) {
          $this->Flagarray = array();
+         $this->Flagarray_DXCC = array();
          $handle = fopen($this->Flagfile,"r");
          if ($handle) {
             $i = 0;
@@ -134,11 +136,12 @@ class xReflector {
          
                if (isset($tmp[0])) { $this->Flagarray[$i]['Country'] = $tmp[0]; } else { $this->Flagarray[$i]['Country'] = 'Undefined'; }
                if (isset($tmp[1])) { $this->Flagarray[$i]['ISO']     = $tmp[1]; } else { $this->Flagarray[$i]['ISO'] = "Undefined"; }
-               $this->Flagarray[$i]['DXCC']    = array();
+               //$this->Flagarray[$i]['DXCC']    = array();
                if (isset($tmp[2])) { 
                   $tmp2 = explode("-", $tmp[2]);
                   for ($j=0;$j<count($tmp2);$j++) {
-                     $this->Flagarray[$i]['DXCC'][] = $tmp2[$j];
+                     //$this->Flagarray[$i]['DXCC'][] = $tmp2[$j];
+                     $this->Flagarray_DXCC[ trim($tmp2[$j]) ] = $i;
                   }
                }
                $i++; 
@@ -256,25 +259,15 @@ class xReflector {
    
    public function GetFlag($Callsign) {
       $Image     = "";
-      $FoundFlag = false;
       $Letters = 4;
       $Name = "";
-      while (($Letters >= 2) && (!$FoundFlag)) {
-         $j = 0;
-         $Prefix = substr($Callsign, 0, $Letters);
-         while (($j < count($this->Flagarray)) && (!$FoundFlag)) {
-            
-            $z = 0;
-            while (($z < count($this->Flagarray[$j]['DXCC'])) && (!$FoundFlag)) {
-               if (trim($Prefix) == trim($this->Flagarray[$j]['DXCC'][$z])) {
-                  $Image = $this->Flagarray[$j]['ISO'];
-                  $Name = $this->Flagarray[$j]['Country'];
-                  $FoundFlag = true;
+      while ($Letters >= 2) {
+         $Prefix = substr(trim($Callsign), 0, $Letters);
+               if (isset($this->Flagarray_DXCC[$Prefix])) {
+                  $Image = $this->Flagarray[ $this->Flagarray_DXCC[$Prefix] ]['ISO'];
+                  $Name  = $this->Flagarray[ $this->Flagarray_DXCC[$Prefix] ]['Country'];
+                  break;
                }
-               $z++;
-            }
-            $j++;
-         }
          $Letters--;
       }
       return array(strtolower($Image), $Name);


### PR DESCRIPTION
Use an array indexed by dxcc prefix for faster lookups instead of scanning whole Flagarray and it's dxcc nested arrays (done lots of times when there are many last heard entries), which is very slow and resource hungry... before this change my server was taking ~360ms to generate users page (with 80 last heard entries), after this small change it takes ~18ms instead.