### PR TITLE
Prevent sending stream close frames back to the sender

### DIFF
--- a/src/cdcsprotocol.cpp
+++ b/src/cdcsprotocol.cpp
@@ -68,7 +68,7 @@ void CDcsProtocol::Task(void)
     CCallsign           Callsign;
     char                ToLinkModule;
     CDvHeaderPacket     *Header;
-    CDvFramePacket      *Frame;
+    CDvFramePacket      *Frame = NULL;
     
     // handle incoming packets
     if ( m_Socket.Receive(&Buffer, &Ip, 20) != -1 )
@@ -89,16 +89,12 @@ void CDcsProtocol::Task(void)
                     //std::cout << "DCS DV frame" << std::endl;
                     OnDvFramePacketIn(Frame, &Ip);
                 }
-                else
-                {
-                    //std::cout << "DCS DV last frame" << std::endl;
-                    OnDvLastFramePacketIn((CDvLastFramePacket *)Frame, &Ip);
-                }
             }
             else
             {
                 delete Header;
                 delete Frame;
+                Frame = NULL;
             }
         }
         else if ( IsValidConnectPacket(Buffer, &Callsign, &ToLinkModule) )
@@ -188,6 +184,11 @@ void CDcsProtocol::Task(void)
     // handle queue from reflector
     HandleQueue();
     
+    if ( Frame != NULL && Frame->IsLastPacket() )
+    {
+        CloseStreamForDvLastFramePacket((CDvLastFramePacket *)Frame, &Ip);
+    }
+
     // keep client alive
     if ( m_LastKeepaliveTime.DurationSinceNow() > DCS_KEEPALIVE_PERIOD )
     {

--- a/src/cdextraprotocol.cpp
+++ b/src/cdextraprotocol.cpp
@@ -69,7 +69,7 @@ void CDextraProtocol::Task(void)
     int                 ProtRev;
     CDvHeaderPacket     *Header;
     CDvFramePacket      *Frame;
-    CDvLastFramePacket  *LastFrame;
+    CDvLastFramePacket  *LastFrame = NULL;
     
     // any incoming packet ?
     if ( m_Socket.Receive(&Buffer, &Ip, 20) != -1 )
@@ -101,9 +101,9 @@ void CDextraProtocol::Task(void)
         else if ( (LastFrame = IsValidDvLastFramePacket(Buffer)) != NULL )
         {
             //std::cout << "DExtra DV last frame" << std::endl;
-            
+
             // handle it
-            OnDvLastFramePacketIn(LastFrame, &Ip);
+            OnDvFramePacketIn(LastFrame, &Ip);
         }
         else if ( IsValidConnectPacket(Buffer, &Callsign, &ToLinkModule, &ProtRev) )
         {
@@ -193,6 +193,11 @@ void CDextraProtocol::Task(void)
     // handle queue from reflector
     HandleQueue();
         
+    if ( LastFrame != NULL )
+    {
+        CloseStreamForDvLastFramePacket(LastFrame, &Ip);
+    }
+
     // keep client alive
     if ( m_LastKeepaliveTime.DurationSinceNow() > DEXTRA_KEEPALIVE_PERIOD )
     {

--- a/src/cdmrmmdvmprotocol.cpp
+++ b/src/cdmrmmdvmprotocol.cpp
@@ -93,7 +93,7 @@ void CDmrmmdvmProtocol::Task(void)
     uint8               CallType;
     CDvHeaderPacket     *Header;
     CDvFramePacket      *Frames[3];
-    CDvLastFramePacket  *LastFrame;
+    CDvLastFramePacket  *LastFrame = NULL;
     
     // handle incoming packets
     if ( m_Socket.Receive(&Buffer, &Ip, 20) != -1 )
@@ -128,8 +128,9 @@ void CDmrmmdvmProtocol::Task(void)
         else if ( IsValidDvLastFramePacket(Buffer, &LastFrame) )
         {
             //std::cout << "DMRmmdvm DV last frame"  << std::endl;
-            
-            OnDvLastFramePacketIn(LastFrame, &Ip);
+
+            // handle it
+            OnDvFramePacketIn(LastFrame, &Ip);
         }
         else if ( IsValidConnectPacket(Buffer, &Callsign, Ip) )
         {
@@ -257,6 +258,10 @@ void CDmrmmdvmProtocol::Task(void)
     // handle queue from reflector
     HandleQueue();
     
+    if ( LastFrame != NULL )
+    {
+        CloseStreamForDvLastFramePacket(LastFrame, &Ip);
+    }
     
     // keep client alive
     if ( m_LastKeepaliveTime.DurationSinceNow() > DMRMMDVM_KEEPALIVE_PERIOD )

--- a/src/cdmrplusprotocol.cpp
+++ b/src/cdmrplusprotocol.cpp
@@ -83,6 +83,7 @@ void CDmrplusProtocol::Task(void)
     char                ToLinkModule;
     CDvHeaderPacket     *Header;
     CDvFramePacket      *Frames[3];
+    int                 CloseStreamFrameNr = -1;
     
     // handle incoming packets
     if ( m_Socket.Receive(&Buffer, &Ip, 20) != -1 )
@@ -99,12 +100,11 @@ void CDmrplusProtocol::Task(void)
                 /*if ( !Frames[i]->IsLastPacket() )
                 {
                     //std::cout << "DMRplus DV frame" << std::endl;
-                    OnDvFramePacketIn(Frames[i], &Ip);
                 }
                 else
                 {
                     //std::cout << "DMRplus DV last frame" << std::endl;
-                    OnDvLastFramePacketIn((CDvLastFramePacket *)Frames[i], &Ip);
+                    CloseStreamFrameNr = i;
                 }*/
             }
         }
@@ -190,6 +190,10 @@ void CDmrplusProtocol::Task(void)
     // handle queue from reflector
     HandleQueue();
     
+    if ( CloseStreamFrameNr >= 0 )
+    {
+        CloseStreamForDvLastFramePacket((CDvLastFramePacket *)Frames[CloseStreamFrameNr], &Ip);
+    }
     
     // keep client alive
     if ( m_LastKeepaliveTime.DurationSinceNow() > DMRPLUS_KEEPALIVE_PERIOD )

--- a/src/cdplusprotocol.cpp
+++ b/src/cdplusprotocol.cpp
@@ -69,7 +69,7 @@ void CDplusProtocol::Task(void)
     CCallsign           Callsign;
     CDvHeaderPacket     *Header;
     CDvFramePacket      *Frame;
-    CDvLastFramePacket  *LastFrame;
+    CDvLastFramePacket  *LastFrame = NULL;
     
     // handle incoming packets
     if ( m_Socket.Receive(&Buffer, &Ip, 20) != -1 )
@@ -100,9 +100,9 @@ void CDplusProtocol::Task(void)
         else if ( (LastFrame = IsValidDvLastFramePacket(Buffer)) != NULL )
         {
             //std::cout << "DPlus DV last frame" << std::endl;
-            
+
             // handle it
-            OnDvLastFramePacketIn(LastFrame, &Ip);
+            OnDvFramePacketIn(LastFrame, &Ip);
        }
         else if ( IsValidConnectPacket(Buffer) )
         {
@@ -180,6 +180,11 @@ void CDplusProtocol::Task(void)
     // handle queue from reflector
     HandleQueue();
     
+    if ( LastFrame )
+    {
+        CloseStreamForDvLastFramePacket(LastFrame, &Ip);
+    }
+
     // keep client alive
     if ( m_LastKeepaliveTime.DurationSinceNow() > DPLUS_KEEPALIVE_PERIOD )
     {

--- a/src/cprotocol.cpp
+++ b/src/cprotocol.cpp
@@ -148,22 +148,6 @@ void CProtocol::OnDvFramePacketIn(CDvFramePacket *Frame, const CIp *Ip)
     }
 }
 
-void CProtocol::OnDvLastFramePacketIn(CDvLastFramePacket *Frame, const CIp *Ip)
-{
-    // find the stream
-    CPacketStream *stream = GetStream(Frame->GetStreamId(), Ip);
-    if ( stream != NULL )
-    {
-        // push
-        stream->Lock();
-        stream->Push(Frame);
-        stream->Unlock();
-        
-        // and close the stream
-        g_Reflector.CloseStream(stream);
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////
 // stream handle helpers
 
@@ -185,6 +169,15 @@ CPacketStream *CProtocol::GetStream(uint16 uiStreamId, const CIp *Ip)
     }
     // done
     return stream;
+}
+
+void CProtocol::CloseStreamForDvLastFramePacket(CDvLastFramePacket *Frame, const CIp *Ip)
+{
+    CPacketStream *stream = GetStream(Frame->GetStreamId(), Ip);
+    if ( stream != NULL )
+    {
+        g_Reflector.CloseStream(stream);
+    }
 }
 
 void CProtocol::CheckStreamsTimeout(void)

--- a/src/cprotocol.h
+++ b/src/cprotocol.h
@@ -100,10 +100,10 @@ protected:
     // stream helpers
     virtual bool OnDvHeaderPacketIn(CDvHeaderPacket *, const CIp &) { return false; }
     virtual void OnDvFramePacketIn(CDvFramePacket *, const CIp * = NULL);
-    virtual void OnDvLastFramePacketIn(CDvLastFramePacket *, const CIp * = NULL);
     
     // stream handle helpers
     CPacketStream *GetStream(uint16, const CIp * = NULL);
+    void CloseStreamForDvLastFramePacket(CDvLastFramePacket *, const CIp * = NULL);
     void CheckStreamsTimeout(void);
     
     // queue helper

--- a/src/cxlxprotocol.cpp
+++ b/src/cxlxprotocol.cpp
@@ -71,7 +71,7 @@ void CXlxProtocol::Task(void)
     CVersion            Version;
     CDvHeaderPacket     *Header;
     CDvFramePacket      *Frame;
-    CDvLastFramePacket  *LastFrame;
+    CDvLastFramePacket  *LastFrame = NULL;
     
     // any incoming packet ?
     if ( m_Socket.Receive(&Buffer, &Ip, 20) != -1 )
@@ -104,8 +104,10 @@ void CXlxProtocol::Task(void)
         {
             //std::cout << "XLX (DExtra) DV last frame" << std::endl;
             
-            // handle it
-            OnDvLastFramePacketIn(LastFrame, &Ip);
+            // tag packet as remote peer origin
+            LastFrame->SetRemotePeerOrigin();
+
+            OnDvFramePacketIn((CDvFramePacket *)LastFrame, &Ip);
         }
         else if ( IsValidConnectPacket(Buffer, &Callsign, Modules, &Version) )
         {
@@ -219,6 +221,11 @@ void CXlxProtocol::Task(void)
     // handle queue from reflector
     HandleQueue();
     
+    if ( LastFrame != NULL )
+    {
+        CloseStreamForDvLastFramePacket(LastFrame, &Ip);
+    }
+
     // keep alive
     if ( m_LastKeepaliveTime.DurationSinceNow() > XLX_KEEPALIVE_PERIOD )
     {
@@ -465,15 +472,6 @@ void CXlxProtocol::OnDvFramePacketIn(CDvFramePacket *DvFrame, const CIp *Ip)
     
     // anc call base class
     CDextraProtocol::OnDvFramePacketIn(DvFrame, Ip);
-}
-
-void CXlxProtocol::OnDvLastFramePacketIn(CDvLastFramePacket *DvFrame, const CIp *Ip)
-{
-    // tag packet as remote peer origin
-    DvFrame->SetRemotePeerOrigin();
-    
-    // anc call base class
-    CDextraProtocol::OnDvLastFramePacketIn(DvFrame, Ip);
 }
 
 

--- a/src/cxlxprotocol.h
+++ b/src/cxlxprotocol.h
@@ -63,7 +63,6 @@ protected:
     // stream helpers
     bool OnDvHeaderPacketIn(CDvHeaderPacket *, const CIp &);
     void OnDvFramePacketIn(CDvFramePacket *, const CIp * = NULL);
-    void OnDvLastFramePacketIn(CDvLastFramePacket *, const CIp * = NULL);
     
     // packet decoding helpers
     bool IsValidKeepAlivePacket(const CBuffer &, CCallsign *);


### PR DESCRIPTION
The OnDvLastFramePacketIn() function closed the current stream before
HandleQueue() was called, so the stream's client lost it's stream master status
and HandleQueue() sent the client's last (stream closing) frame back to the
sender.

Applying this commit closes the stream only after HandleQueue() has been
called so no unnecessary call end frame reflection happens to the transmitting
client.