### PR TITLE
Add Icom G3 Terminal protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Copyright
 
-© 2016 Luc Engelmann LX1IQ
+Â© 2016 Luc Engelmann LX1IQ
 
 The XLX Multiprotocol Gateway Reflector Server is part of the software system
 for the D-Star Network.
@@ -120,5 +120,7 @@ XLX Server requires the following ports to be open and forwarded properly for in
  - UDP port 62030         (MMDVM protocol)
  - UDP port 10100         (AMBE controller port)
  - UDP port 10101 - 10199 (AMBE transcoding port)
+ - UDP port 12345 - 12346 (Icom Terminal presence and request port)
+ - UDP port 40000         (Icom Terminal dv port)
 
-© 2016 Luc Engelmann LX1IQ
+Â© 2016 Luc Engelmann LX1IQ

--- a/config/xlxd.terminal
+++ b/config/xlxd.terminal
@@ -1,0 +1,17 @@
+#########################################################################################
+#  XLXD terminal option file
+#
+#  one line per entry
+#  each entry specifies a terminal option
+#
+#  Valid option:
+#  address <ip>      - Ip address to be used by the terminal route responder
+#                      By default, the request destination address is used.
+#                      If the system is behind a router, set it to the public IP
+#                      If the system runs on the public IP, leave unset.
+#  modules <modules> - a string with all modules to accept a terminal connection
+#                      Default value is "*", meaning accept all
+#
+#########################################################################################
+#address 193.1.2.3
+#modules BCD

--- a/src/cg3client.cpp
+++ b/src/cg3client.cpp
@@ -1,0 +1,54 @@
+//
+//  cg3client.cpp
+//  xlxd
+//
+//  Created by Marius Petrescu (YO2LOJ) on 03/06/2019.
+//  Copyright © 2019 Marius Petrescu (YO2LOJ). All rights reserved.
+//
+// ----------------------------------------------------------------------------
+//    This file is part of xlxd.
+//
+//    xlxd is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    xlxd is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Foobar.  If not, see <http://www.gnu.org/licenses/>. 
+// ----------------------------------------------------------------------------
+
+#include "main.h"
+#include "cg3client.h"
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// constructors
+
+CG3Client::CG3Client()
+{
+}
+
+CG3Client::CG3Client(const CCallsign &callsign, const CIp &ip, char reflectorModule)
+    : CClient(callsign, ip, reflectorModule)
+{
+
+}
+
+CG3Client::CG3Client(const CG3Client &client)
+    : CClient(client)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// status
+
+bool CG3Client::IsAlive(void) const
+{
+    return (m_LastKeepaliveTime.DurationSinceNow() < G3_KEEPALIVE_TIMEOUT);
+}
+

--- a/src/cg3client.h
+++ b/src/cg3client.h
@@ -1,9 +1,9 @@
 //
-//  cudpsocket.h
+//  cg3client.h
 //  xlxd
 //
-//  Created by Jean-Luc Deltombe (LX3JL) on 31/10/2015.
-//  Copyright © 2015 Jean-Luc Deltombe (LX3JL). All rights reserved.
+//  Created by Marius Petrescu (YO2LOJ) on 03/06/2019.
+//  Copyright © 2019 Marius Petrescu (YO2LOJ). All rights reserved.
 //
 // ----------------------------------------------------------------------------
 //    This file is part of xlxd.
@@ -22,59 +22,41 @@
 //    along with Foobar.  If not, see <http://www.gnu.org/licenses/>. 
 // ----------------------------------------------------------------------------
 
-#ifndef cudpsocket_h
-#define cudpsocket_h
+#ifndef cg3client_h
+#define cg3client_h
 
-#include <sys/types.h>
-//#include <sys/stat.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <arpa/inet.h>
-
-#include "cip.h"
-#include "cbuffer.h"
+#include "cclient.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // define
-
-#define UDP_BUFFER_LENMAX       1024
 
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // class
 
-class CUdpSocket
+class CG3Client : public CClient
 {
 public:
-    // constructor
-    CUdpSocket();
+    // constructors
+    CG3Client();
+    CG3Client(const CCallsign &, const CIp &, char = ' ');
+    CG3Client(const CG3Client &);
     
     // destructor
-    ~CUdpSocket();
+    virtual ~CG3Client() {};
     
-    // open & close
-    bool Open(uint16);
-    void Close(void);
-    int  GetSocket(void)        { return m_Socket; }
+    // identity
+    int GetProtocol(void) const                 { return PROTOCOL_G3; }
+    const char *GetProtocolName(void) const     { return "Terminal/AP"; }
+    int GetCodec(void) const                    { return CODEC_AMBEPLUS; }
+    bool IsNode(void) const                     { return true; }
     
-    // read
-    int Receive(CBuffer *, CIp *, int);
-    
-    // write
-    int Send(const CBuffer &, const CIp &);
-    int Send(const CBuffer &, const CIp &, uint16);
-    int Send(const char *, const CIp &);
-    int Send(const char *, const CIp &, uint16);
-    
-    struct in_addr *GetLocalAddr(void)   { return &m_LocalAddr; }
+    // status
+    bool IsAlive(void) const;
+
 protected:
     // data
-    int                 m_Socket;
-    struct sockaddr_in  m_SocketAddr;
-    struct in_addr      m_LocalAddr;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////
-#endif /* cudpsocket_h */
+#endif /* cg3client_h */

--- a/src/cg3protocol.cpp
+++ b/src/cg3protocol.cpp
@@ -201,6 +201,8 @@ void CG3Protocol::PresenceTask(void)
 
             if (extant == NULL)
             {
+                index = -1;
+                
                 // do we already have a client with the same call (IP changed)?
                 while ( (extant = clients->FindNextClient(PROTOCOL_G3, &index)) != NULL )
                 {
@@ -222,7 +224,6 @@ void CG3Protocol::PresenceTask(void)
             }
             else
             {
-                index = -1;
                 // client changed callsign
                 if (!extant->GetCallsign().HasSameCallsign(Terminal))
                 {

--- a/src/cg3protocol.cpp
+++ b/src/cg3protocol.cpp
@@ -222,6 +222,7 @@ void CG3Protocol::PresenceTask(void)
             }
             else
             {
+                index = -1;
                 // client changed callsign
                 if (!extant->GetCallsign().HasSameCallsign(Terminal))
                 {

--- a/src/cg3protocol.cpp
+++ b/src/cg3protocol.cpp
@@ -1,0 +1,726 @@
+//
+//  cg3protocol.cpp
+//  xlxd
+//
+//  Created by Marius Petrescu (YO2LOJ) on 03/06/2019.
+//  Copyright © 2019 Marius Petrescu (YO2LOJ). All rights reserved.
+//
+// ----------------------------------------------------------------------------
+//    This file is part of xlxd.
+//
+//    xlxd is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    xlxd is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Foobar.  If not, see <http://www.gnu.org/licenses/>. 
+// ----------------------------------------------------------------------------
+
+#include "main.h"
+#include <string.h>
+#include "cg3client.h"
+#include "cg3protocol.h"
+#include "creflector.h"
+#include "cgatekeeper.h"
+
+#include <netinet/ip.h>
+#include <netinet/ip_icmp.h>
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// operation
+
+bool CG3Protocol::Init(void)
+{
+    bool ok;
+
+    // base class
+    ok = CProtocol::Init();
+
+    // update reflector callsign
+    m_ReflectorCallsign.PatchCallsign(0, (const uint8 *)"XRF", 3);
+
+    // create our DV socket
+    ok &= m_Socket.Open(G3_DV_PORT);
+    if ( !ok )
+    {
+        std::cout << "Error opening socket on port UDP" << G3_DV_PORT << " on ip " << g_Reflector.GetListenIp() << std::endl;
+    }
+
+    //create helper sockets
+    ok &= m_PresenceSocket.Open(G3_PRESENCE_PORT);
+    if ( !ok )
+    {
+        std::cout << "Error opening socket on port UDP" << G3_PRESENCE_PORT << " on ip " << g_Reflector.GetListenIp() << std::endl;
+    }
+
+    ok &= m_ConfigSocket.Open(G3_CONFIG_PORT);
+    if ( !ok )
+    {
+        std::cout << "Error opening socket on port UDP" << G3_CONFIG_PORT << " on ip " << g_Reflector.GetListenIp() << std::endl;
+    }
+
+    ok &= ((m_IcmpRawSocket = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP)) >= 0);
+    if ( !ok )
+    {
+        std::cout << "Error opening raw socket for ICMP" << std::endl;
+    }
+
+    if (ok)
+    {
+        // start helper threads
+        m_pPresenceThread = new std::thread(PresenceThread, this);
+        m_pPresenceThread = new std::thread(ConfigThread, this);
+        m_pPresenceThread = new std::thread(IcmpThread, this);
+    }
+
+    // update time
+    m_LastKeepaliveTime.Now();
+
+    // done
+    return ok;
+}
+
+void CG3Protocol::Close(void)
+{
+    if (m_pPresenceThread != NULL)
+    {
+        m_pPresenceThread->join();
+        delete m_pPresenceThread;
+        m_pPresenceThread = NULL;
+    }
+
+    if (m_pConfigThread != NULL)
+    {
+        m_pConfigThread->join();
+        delete m_pConfigThread;
+        m_pConfigThread = NULL;
+    }
+
+    if (m_pIcmpThread != NULL)
+    {
+        m_pIcmpThread->join();
+        delete m_pIcmpThread;
+        m_pIcmpThread = NULL;
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// private threads
+
+void CG3Protocol::PresenceThread(CG3Protocol *This)
+{
+    while ( !This->m_bStopThread )
+    {
+        This->PresenceTask();
+    }
+}
+
+void CG3Protocol::ConfigThread(CG3Protocol *This)
+{
+    while ( !This->m_bStopThread )
+    {
+        This->ConfigTask();
+    }
+}
+
+void CG3Protocol::IcmpThread(CG3Protocol *This)
+{
+    fcntl(This->m_IcmpRawSocket, F_SETFL, O_NONBLOCK);
+
+    while ( !This->m_bStopThread )
+    {
+        This->IcmpTask();
+    }
+
+    close(This->m_IcmpRawSocket);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// presence task
+
+void CG3Protocol::PresenceTask(void)
+{
+    CBuffer             Buffer;
+    CIp                 ReqIp;
+    CCallsign           Callsign;
+    CCallsign           Owner;
+    CCallsign           Terminal;
+
+
+    if ( m_PresenceSocket.Receive(&Buffer, &ReqIp, 20) != -1 )
+    {
+
+        CIp Ip(ReqIp);
+        Ip.GetSockAddr()->sin_port = htons(G3_DV_PORT);
+
+        if (Buffer.size() == 32)
+        {
+            Callsign.SetCallsign(&Buffer.data()[8], 8);
+            Owner.SetCallsign(&Buffer.data()[16], 8);
+            Terminal.SetCallsign(&Buffer.data()[24], 8);
+
+            std::cout << "Presence from " << Ip << " as " << Callsign << " on terminal " << Terminal << std::endl; 
+
+            // accept
+            Buffer.data()[2] = 0x80; // response
+            Buffer.data()[3] = 0x00; // ok
+
+            // todo: handle reflector IP 0.0.0.0
+            Buffer.Append(g_Reflector.GetListenIp().GetAddr()); 
+
+            CClients *clients = g_Reflector.GetClients();
+
+            int index = -1;
+            CClient *extant = NULL;
+            while ( (extant = clients->FindNextClient(PROTOCOL_G3, &index)) != NULL )
+            {
+                CIp ClIp = extant->GetIp();
+                if (ClIp.GetAddr() == Ip.GetAddr())
+                {
+                    break;
+                }
+            }
+
+            if (extant == NULL)
+            {
+                // create client
+                CG3Client *client = new CG3Client(Terminal, Ip);
+
+                // and append
+                clients->AddClient(client);
+            }
+            else
+            {
+                if (!extant->GetCallsign().HasSameCallsign(Terminal))
+                {
+                    //delete old client
+                    clients->RemoveClient(extant);
+
+                    // create new client
+                    CG3Client *client = new CG3Client(Terminal, Ip);
+
+                    // and append
+                    clients->AddClient(client);
+                }
+            }
+            g_Reflector.ReleaseClients();
+
+            m_PresenceSocket.Send(Buffer, ReqIp);
+        }
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// configuration task
+
+void CG3Protocol::ConfigTask(void)
+{
+    CBuffer             Buffer;
+    CIp                 Ip;
+    CCallsign           Call;
+    bool                isRepeaterCall;
+
+    if ( m_ConfigSocket.Receive(&Buffer, &Ip, 20) != -1 )
+    {
+
+        if (Buffer.size() == 16)
+        {
+            if (memcmp(&Buffer.data()[8], "        ", 8) == 0)
+            {
+                Call.SetCallsign(GetReflectorCallsign(), 8);
+            }
+            else
+            {
+                Call.SetCallsign(&Buffer.data()[8], 8);
+            }
+
+            isRepeaterCall = ((Buffer.data()[2] & 0x10) == 0x10);
+
+            std::cout << "Config request from " << Ip << " for " << Call << " (" << ((char *)(isRepeaterCall)?"repeater":"routed") << ")" << std::endl;
+
+            //std::cout << "Local address: " << inet_ntoa(*m_ConfigSocket.GetLocalAddr()) << std::endl;
+
+            Buffer.data()[2] |= 0x80; // response
+
+            if (isRepeaterCall)
+            {
+                if ((Call.HasSameCallsign(GetReflectorCallsign())) && (g_Reflector.IsValidModule(Call.GetModule())))
+                {
+                    Buffer.data()[3] = 0x00; // ok
+                }
+                else
+                {
+                    Buffer.data()[3] = 0x01; // reject
+                }
+            }
+            else
+            {
+                // reject routed calls for now
+                Buffer.data()[3] = 0x01; // reject
+            }
+
+            // UR
+            Buffer.resize(8);
+            Buffer.Append((uint8 *)(const char *)Call, CALLSIGN_LEN - 1);
+            Buffer.Append((uint8)Call.GetModule());
+
+            // RPT1
+            Buffer.Append((uint8 *)(const char *)GetReflectorCallsign(), CALLSIGN_LEN - 1);
+            Buffer.Append((uint8)'G');
+
+            // RPT2
+            Buffer.Append((uint8 *)(const char *)GetReflectorCallsign(), CALLSIGN_LEN - 1);
+
+            if (isRepeaterCall)
+            {
+                Buffer.Append((uint8)Call.GetModule());
+            }
+            else
+            {
+                // routed - no module for now
+                Buffer.Append((uint8)' ');
+            }
+
+            if (Buffer.data()[3] == 0x00)
+            {
+                Buffer.Append(*(uint32 *)m_ConfigSocket.GetLocalAddr()); 
+            }
+            else
+            {
+                Buffer.Append(0u);
+            }
+
+            m_ConfigSocket.Send(Buffer, Ip);
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// icmp task
+
+void CG3Protocol::IcmpTask(void)
+{
+    unsigned char buffer[256];
+
+    struct sockaddr_in sa;
+    unsigned int sasize = sizeof(sa);
+
+    fd_set FdSet;
+    struct timeval tv;
+
+    if (m_IcmpRawSocket != -1)
+    {
+        FD_ZERO(&FdSet);
+        FD_SET(m_IcmpRawSocket, &FdSet);
+        tv.tv_sec = 0;
+        tv.tv_usec = 100000;
+        select(m_IcmpRawSocket + 1, &FdSet, 0, 0, &tv);
+
+        int len = recvfrom(m_IcmpRawSocket, buffer, 255, 0, (struct sockaddr *)&sa, &sasize);
+
+        if (len > 28)
+        {
+            struct ip *iph = (struct ip *)buffer;
+            int iphdrlen = iph->ip_hl * 4;
+            struct icmp *icmph = (struct icmp *)(buffer + iphdrlen);
+
+            if (icmph->icmp_type == ICMP_DEST_UNREACH)
+            {
+                struct ip *remote_iph = (struct ip *)(buffer + iphdrlen + 8);
+
+                CClients *clients = g_Reflector.GetClients();
+
+                int index = -1;
+                CClient *client = NULL;
+                while ( (client = clients->FindNextClient(PROTOCOL_G3, &index)) != NULL )
+                {
+                    CIp Ip = client->GetIp();
+                    if (Ip.GetAddr() == remote_iph->ip_dst.s_addr)
+                    {
+                        clients->RemoveClient(client);
+                    }
+                }
+                g_Reflector.ReleaseClients();
+
+            }
+        }
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// task
+
+void CG3Protocol::Task(void)
+{
+    CBuffer             Buffer;
+    CIp                 Ip;
+    CCallsign           Callsign;
+    char                ToLinkModule;
+    int                 ProtRev;
+    CDvHeaderPacket     *Header;
+    CDvFramePacket      *Frame;
+    CDvLastFramePacket  *LastFrame;
+
+    // any incoming packet ?
+    if ( m_Socket.Receive(&Buffer, &Ip, 20) != -1 )
+    {
+        CIp ClIp;
+        CIp *BaseIp = NULL;
+        CClients *clients = g_Reflector.GetClients();
+        int index = -1;
+        CClient *client = NULL;
+        while ( (client = clients->FindNextClient(PROTOCOL_G3, &index)) != NULL )
+        {
+            ClIp = client->GetIp();
+            if (ClIp.GetAddr() == Ip.GetAddr())
+            {
+                BaseIp = &ClIp;
+                client->Alive();
+                // supress host checks
+                m_LastKeepaliveTime.Now();
+                break;
+            }
+        }
+        g_Reflector.ReleaseClients();
+
+        if (BaseIp != NULL)
+        {
+            // crack the packet
+            if ( (Frame = IsValidDvFramePacket(Buffer)) != NULL )
+            {
+                //std::cout << "Terminal DV frame"  << std::endl;
+            
+                // handle it
+                OnDvFramePacketIn(Frame, BaseIp);
+            }
+            else if ( (Header = IsValidDvHeaderPacket(Buffer)) != NULL )
+            {
+                //std::cout << "Terminal DV header"  << std::endl;
+            
+                // callsign muted?
+                if ( g_GateKeeper.MayTransmit(Header->GetMyCallsign(), Ip, PROTOCOL_G3, Header->GetRpt2Module()) )
+                {
+                    // handle it
+                    OnDvHeaderPacketIn(Header, *BaseIp);
+                }
+                else
+                {
+                    delete Header;
+                }
+            }
+            else if ( (LastFrame = IsValidDvLastFramePacket(Buffer)) != NULL )
+            {
+                //std::cout << "Terminal DV last frame" << std::endl;
+            
+                // handle it
+                OnDvLastFramePacketIn(LastFrame, BaseIp);
+            }
+            else
+            {
+                //std::cout << "Invalid terminal packet (" << Buffer.size() << ")" << std::endl;
+                //std::cout << Buffer.data() << std::endl;
+            }
+        }
+        else
+        {
+            //std::cout << "Invalid client " <<  Ip << std::endl;
+        }
+    }
+
+    // handle end of streaming timeout
+    CheckStreamsTimeout();
+        
+    // handle queue from reflector
+    HandleQueue();
+        
+    // keep alive
+    if ( m_LastKeepaliveTime.DurationSinceNow() > G3_KEEPALIVE_PERIOD )
+    {
+        // handle keep alives
+        HandleKeepalives();
+        
+        // update time
+        m_LastKeepaliveTime.Now();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// queue helper
+
+void CG3Protocol::HandleQueue(void)
+{
+    m_Queue.Lock();
+    while ( !m_Queue.empty() )
+    {
+        // supress host checks
+        m_LastKeepaliveTime.Now();
+
+        // get the packet
+        CPacket *packet = m_Queue.front();
+        m_Queue.pop();
+        
+        // encode it
+        CBuffer buffer;
+        if ( EncodeDvPacket(*packet, &buffer) )
+        {
+            // and push it to all our clients linked to the module and who are not streaming in
+            CClients *clients = g_Reflector.GetClients();
+            int index = -1;
+            CClient *client = NULL;
+            while ( (client = clients->FindNextClient(PROTOCOL_G3, &index)) != NULL )
+            {
+                // is this client busy ?
+                if ( !client->IsAMaster() && (client->GetReflectorModule() == packet->GetModuleId()) )
+                {
+                    // not busy, send the packet
+                    int n = packet->IsDvHeader() ? 5 : 1;
+                    for ( int i = 0; i < n; i++ )
+                    {
+                        m_Socket.Send(buffer, client->GetIp());
+                    }
+                }
+            }
+            g_Reflector.ReleaseClients();
+        }
+        
+        // done
+        delete packet;
+    }
+    m_Queue.Unlock();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// keepalive helpers
+
+void CG3Protocol::HandleKeepalives(void)
+{
+    // G3 Terminal mode does not support keepalive
+    // We will send some short packed and expect
+    // A ICMP unreachable on failure
+    CBuffer keepalive((uint8 *)"PING", 4);
+
+    // iterate on clients
+    CClients *clients = g_Reflector.GetClients();
+    int index = -1;
+    CClient *client = NULL;
+    while ( (client = clients->FindNextClient(PROTOCOL_G3, &index)) != NULL )
+    {
+        if (!client->IsAlive())
+        {
+            clients->RemoveClient(client);
+        }
+        else
+        {
+            // send keepalive packet
+            m_Socket.Send(keepalive, client->GetIp());
+        }
+    }
+    g_Reflector.ReleaseClients();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// streams helpers
+
+bool CG3Protocol::OnDvHeaderPacketIn(CDvHeaderPacket *Header, const CIp &Ip)
+{
+    bool newstream = false;
+
+    // find the stream
+    CPacketStream *stream = GetStream(Header->GetStreamId(), &Ip);
+
+    if ( stream == NULL )
+    {
+        // no stream open yet, open a new one
+        CCallsign via(Header->GetRpt1Callsign());
+
+        // find this client
+        CClients *clients = g_Reflector.GetClients();
+
+        int index = -1;
+        CClient *client = NULL;
+        while ( (client = clients->FindNextClient(PROTOCOL_G3, &index)) != NULL )
+        {
+            CIp ClIp = client->GetIp();
+            if (ClIp.GetAddr() == Ip.GetAddr())
+            {
+                break;
+            }
+        }
+
+        if ( client != NULL )
+        {
+
+            // move it to the proper module
+            if (m_ReflectorCallsign.HasSameCallsign(Header->GetRpt2Callsign()))
+            {
+                if (client->GetReflectorModule() != Header->GetRpt2Callsign().GetModule())
+                {
+                    client->SetReflectorModule(Header->GetRpt2Callsign().GetModule());
+                }
+
+                // get client callsign
+                via = client->GetCallsign();
+
+                // and try to open the stream
+                if ( (stream = g_Reflector.OpenStream(Header, client)) != NULL )
+                {
+                    // keep the handle
+                    m_Streams.push_back(stream);
+                    newstream = true;
+                }
+
+                // update last heard
+                g_Reflector.GetUsers()->Hearing(Header->GetMyCallsign(), via, Header->GetRpt2Callsign());
+                g_Reflector.ReleaseUsers();
+
+                // delete header if needed
+                if ( !newstream )
+                {
+                    delete Header;
+                }
+
+            }
+            else
+            {
+                // drop
+                delete Header;
+            }
+        }
+        // release
+        g_Reflector.ReleaseClients();
+    }
+    else
+    {
+        // stream already open
+        // skip packet, but tickle the stream
+        stream->Tickle();
+        // and delete packet
+        delete Header;
+    }
+
+    // done
+    return newstream;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// packet decoding helpers
+
+CDvHeaderPacket *CG3Protocol::IsValidDvHeaderPacket(const CBuffer &Buffer)
+{
+    CDvHeaderPacket *header = NULL;
+    
+    if ( (Buffer.size() == 56) && (Buffer.Compare((uint8 *)"DSVT", 4) == 0) &&
+         (Buffer.data()[4] == 0x10) && (Buffer.data()[8] == 0x20) )
+    {
+        // create packet
+        header = new CDvHeaderPacket((struct dstar_header *)&(Buffer.data()[15]),
+                                *((uint16 *)&(Buffer.data()[12])), 0x80);
+        // check validity of packet
+        if ( !header->IsValid() )
+        {
+            delete header;
+            header = NULL;
+        }
+    }
+    return header;
+}
+
+CDvFramePacket *CG3Protocol::IsValidDvFramePacket(const CBuffer &Buffer)
+{
+    CDvFramePacket *dvframe = NULL;
+    
+    if ( (Buffer.size() == 27) && (Buffer.Compare((uint8 *)"DSVT", 4) == 0) &&
+         (Buffer.data()[4] == 0x20) && (Buffer.data()[8] == 0x20) &&
+         ((Buffer.data()[14] & 0x40) == 0) )
+    {
+        // create packet
+        dvframe = new CDvFramePacket((struct dstar_dvframe *)&(Buffer.data()[15]),
+                                     *((uint16 *)&(Buffer.data()[12])), Buffer.data()[14]);
+        // check validity of packet
+        if ( !dvframe->IsValid() )
+        {
+            delete dvframe;
+            dvframe = NULL;
+        }
+    }
+    return dvframe;
+}
+
+CDvLastFramePacket *CG3Protocol::IsValidDvLastFramePacket(const CBuffer &Buffer)
+{
+    CDvLastFramePacket *dvframe = NULL;
+    
+    if ( (Buffer.size() == 27) && (Buffer.Compare((uint8 *)"DSVT", 4) == 0) &&
+         (Buffer.data()[4] == 0x20) && (Buffer.data()[8] == 0x20) &&
+         ((Buffer.data()[14] & 0x40) != 0) )
+    {
+        // create packet
+        dvframe = new CDvLastFramePacket((struct dstar_dvframe *)&(Buffer.data()[15]),
+                                         *((uint16 *)&(Buffer.data()[12])), Buffer.data()[14]);
+        // check validity of packet
+        if ( !dvframe->IsValid() )
+        {
+            delete dvframe;
+            dvframe = NULL;
+        }
+    }
+    return dvframe;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// packet encoding helpers
+
+bool CG3Protocol::EncodeDvHeaderPacket(const CDvHeaderPacket &Packet, CBuffer *Buffer) const
+{
+    uint8 tag[]	= { 'D','S','V','T',0x10,0x00,0x00,0x00,0x20,0x00,0x01,0x02 };
+    struct dstar_header DstarHeader;
+    
+    Packet.ConvertToDstarStruct(&DstarHeader);
+    
+    Buffer->Set(tag, sizeof(tag));
+    Buffer->Append(Packet.GetStreamId());
+    Buffer->Append((uint8)0x80);
+    Buffer->Append((uint8 *)&DstarHeader, sizeof(struct dstar_header));
+    
+    return true;
+}
+
+bool CG3Protocol::EncodeDvFramePacket(const CDvFramePacket &Packet, CBuffer *Buffer) const
+{
+    uint8 tag[] = { 'D','S','V','T',0x20,0x00,0x00,0x00,0x20,0x00,0x01,0x02 };
+    
+    Buffer->Set(tag, sizeof(tag));
+    Buffer->Append(Packet.GetStreamId());
+    Buffer->Append((uint8)(Packet.GetPacketId() % 21));
+    Buffer->Append((uint8 *)Packet.GetAmbe(), AMBE_SIZE);
+    Buffer->Append((uint8 *)Packet.GetDvData(), DVDATA_SIZE);
+    
+    return true;
+    
+}
+
+bool CG3Protocol::EncodeDvLastFramePacket(const CDvLastFramePacket &Packet, CBuffer *Buffer) const
+{
+    uint8 tag1[] = { 'D','S','V','T',0x20,0x00,0x00,0x00,0x20,0x00,0x01,0x02 };
+    uint8 tag2[] = { 0x55,0xC8,0x7A,0x00,0x00,0x00,0x00,0x00,0x00,0x25,0x1A,0xC6 };
+    
+    Buffer->Set(tag1, sizeof(tag1));
+    Buffer->Append(Packet.GetStreamId());
+    Buffer->Append((uint8)((Packet.GetPacketId() % 21) | 0x40));
+    Buffer->Append(tag2, sizeof(tag2));
+    
+    return true;
+}
+

--- a/src/cg3protocol.cpp
+++ b/src/cg3protocol.cpp
@@ -798,7 +798,7 @@ char *CG3Protocol::TrimWhiteSpaces(char *str)
 }
 
 
-bool CG3Protocol::NeedReload(void)
+void CG3Protocol::NeedReload(void)
 {
     struct stat fileStat;
 

--- a/src/cg3protocol.cpp
+++ b/src/cg3protocol.cpp
@@ -44,7 +44,7 @@ bool CG3Protocol::Init(void)
     ok = CProtocol::Init();
 
     // update reflector callsign
-    m_ReflectorCallsign.PatchCallsign(0, (const uint8 *)"XRF", 3);
+    m_ReflectorCallsign.PatchCallsign(0, (const uint8 *)"XLX", 3);
 
     // create our DV socket
     ok &= m_Socket.Open(G3_DV_PORT);

--- a/src/cg3protocol.h
+++ b/src/cg3protocol.h
@@ -90,7 +90,7 @@ protected:
 
     // helper
     char *TrimWhiteSpaces(char *);
-    bool NeedReload(void);
+    void NeedReload(void);
 
     // queue helper
     void HandleQueue(void);

--- a/src/cg3protocol.h
+++ b/src/cg3protocol.h
@@ -25,6 +25,7 @@
 #ifndef cg3protocol_h
 #define cg3protocol_h
 
+#include <string>
 #include "ctimepoint.h"
 #include "cprotocol.h"
 #include "cdvheaderpacket.h"
@@ -59,7 +60,7 @@ class CG3Protocol : public CProtocol
 {
 public:
     // constructor
-    CG3Protocol() {};
+    CG3Protocol() : m_GwAddress(0u), m_Modules("*"), m_LastModTime(0) {};
     
     // destructor
     virtual ~CG3Protocol() {};
@@ -84,6 +85,13 @@ protected:
     void ConfigTask(void);
     void IcmpTask(void);
 
+    // config
+    void ReadOptions(void);
+
+    // helper
+    char *TrimWhiteSpaces(char *);
+    bool NeedReload(void);
+
     // queue helper
     void HandleQueue(void);
 
@@ -97,12 +105,12 @@ protected:
     CDvHeaderPacket     *IsValidDvHeaderPacket(const CBuffer &);
     CDvFramePacket      *IsValidDvFramePacket(const CBuffer &);
     CDvLastFramePacket  *IsValidDvLastFramePacket(const CBuffer &);
-    
+
     // packet encoding helpers
     bool                EncodeDvHeaderPacket(const CDvHeaderPacket &, CBuffer *) const;
     bool                EncodeDvFramePacket(const CDvFramePacket &, CBuffer *) const;
     bool                EncodeDvLastFramePacket(const CDvLastFramePacket &, CBuffer *) const;
-    
+
 protected:
     std::thread         *m_pPresenceThread;
     std::thread         *m_pConfigThread;
@@ -116,6 +124,11 @@ protected:
     CUdpSocket          m_PresenceSocket;
     CUdpSocket          m_ConfigSocket;
     int                 m_IcmpRawSocket;
+
+    // optional params
+    uint32              m_GwAddress;
+    std::string         m_Modules;
+    time_t              m_LastModTime;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cg3protocol.h
+++ b/src/cg3protocol.h
@@ -1,0 +1,122 @@
+//
+//  cg3protocol.h
+//  xlxd
+//
+//  Created by Marius Petrescu (YO2LOJ) on 03/06/2019.
+//  Copyright © 2019 Marius Petrescu (YO2LOJ). All rights reserved.
+//
+// ----------------------------------------------------------------------------
+//    This file is part of xlxd.
+//
+//    xlxd is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    xlxd is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Foobar.  If not, see <http://www.gnu.org/licenses/>. 
+// ----------------------------------------------------------------------------
+
+#ifndef cg3protocol_h
+#define cg3protocol_h
+
+#include "ctimepoint.h"
+#include "cprotocol.h"
+#include "cdvheaderpacket.h"
+#include "cdvframepacket.h"
+#include "cdvlastframepacket.h"
+
+////////////////////////////////////////////////////////////////////////////////////////
+
+// note on the G3 terminal/AP protocol:
+//
+// There are 3 steps in handling an incoming connection
+//
+// 1 - Notification of terminal call on port UDP 12346
+//      - Call will be rejected if in blacklisted
+//
+// 2 - Destination request on port UDP 12345
+//      - Calls to specific callsigns will be accepted for a default module
+//      - Repeater calls will be accepted for local modules
+//      - All other calls are rehected
+//
+// 3 - Actual D-star flow like in Dextra to/from port 40000 (2 distint sockets)
+//
+// Alive monitoring is done via a "PING" to remote port 40000. We will get an
+// ICMP unreachable on terminal mode close or on station shut down if routing is done
+// correctly. Otherwise a long timeout is used (e.g. 1h)
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// class
+
+class CG3Protocol : public CProtocol
+{
+public:
+    // constructor
+    CG3Protocol() {};
+    
+    // destructor
+    virtual ~CG3Protocol() {};
+    
+    // initialization
+    bool Init(void);
+
+    // close
+    void Close(void);
+    
+    // task
+    void Task(void);
+
+protected:
+    // threads
+    static void PresenceThread(CG3Protocol *);
+    static void ConfigThread(CG3Protocol *);
+    static void IcmpThread(CG3Protocol *);
+
+    // helper tasks
+    void PresenceTask(void);
+    void ConfigTask(void);
+    void IcmpTask(void);
+
+    // queue helper
+    void HandleQueue(void);
+
+    // keepalive helpers
+    void HandleKeepalives(void);
+
+    // stream helpers
+    bool OnDvHeaderPacketIn(CDvHeaderPacket *, const CIp &);
+
+    // packet decoding helpers
+    CDvHeaderPacket     *IsValidDvHeaderPacket(const CBuffer &);
+    CDvFramePacket      *IsValidDvFramePacket(const CBuffer &);
+    CDvLastFramePacket  *IsValidDvLastFramePacket(const CBuffer &);
+    
+    // packet encoding helpers
+    bool                EncodeDvHeaderPacket(const CDvHeaderPacket &, CBuffer *) const;
+    bool                EncodeDvFramePacket(const CDvFramePacket &, CBuffer *) const;
+    bool                EncodeDvLastFramePacket(const CDvLastFramePacket &, CBuffer *) const;
+    
+protected:
+    std::thread         *m_pPresenceThread;
+    std::thread         *m_pConfigThread;
+    std::thread         *m_pIcmpThread;
+
+    // time
+    CTimePoint          m_LastKeepaliveTime;
+
+    // sockets
+    CUdpSocket          m_DvOutSocket;
+    CUdpSocket          m_PresenceSocket;
+    CUdpSocket          m_ConfigSocket;
+    int                 m_IcmpRawSocket;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////
+#endif /* cg3protocol_h */

--- a/src/cgatekeeper.cpp
+++ b/src/cgatekeeper.cpp
@@ -101,6 +101,7 @@ bool CGateKeeper::MayLink(const CCallsign &callsign, const CIp &ip, int protocol
         case PROTOCOL_DCS:
         case PROTOCOL_DMRPLUS:
         case PROTOCOL_DMRMMDVM:
+        case PROTOCOL_G3:
             // first check is IP & callsigned listed OK
             ok &= IsNodeListedOk(callsign, ip);
             // todo: then apply any protocol specific authorisation for the operation
@@ -141,6 +142,7 @@ bool CGateKeeper::MayTransmit(const CCallsign &callsign, const CIp &ip, int prot
         case PROTOCOL_DCS:
         case PROTOCOL_DMRPLUS:
         case PROTOCOL_DMRMMDVM:
+        case PROTOCOL_G3:
             // first check is IP & callsigned listed OK
             ok &= IsNodeListedOk(callsign, ip, module);
             // todo: then apply any protocol specific authorisation for the operation

--- a/src/cprotocols.cpp
+++ b/src/cprotocols.cpp
@@ -29,6 +29,7 @@
 #include "cxlxprotocol.h"
 #include "cdmrplusprotocol.h"
 #include "cdmrmmdvmprotocol.h"
+#include "cg3protocol.h"
 #include "cprotocols.h"
 
 
@@ -96,6 +97,11 @@ bool CProtocols::Init(void)
         delete m_Protocols[5];
         m_Protocols[5] = new CDmrmmdvmProtocol;
         ok &= m_Protocols[5]->Init();
+        
+        // create and initialize G3
+        delete m_Protocols[6];
+        m_Protocols[6] = new CG3Protocol;
+        ok &= m_Protocols[6]->Init();
     }
     m_Mutex.unlock();
    

--- a/src/main.h
+++ b/src/main.h
@@ -65,7 +65,7 @@
 
 // protocols ---------------------------------------------------
 
-#define NB_OF_PROTOCOLS                 6
+#define NB_OF_PROTOCOLS                 7
 
 #define PROTOCOL_ANY                    -1
 #define PROTOCOL_NONE                   0
@@ -75,6 +75,7 @@
 #define PROTOCOL_XLX                    4
 #define PROTOCOL_DMRPLUS                5
 #define PROTOCOL_DMRMMDVM               6
+#define PROTOCOL_G3                     7
 
 // DExtra
 #define DEXTRA_PORT                     30001                               // UDP port
@@ -110,6 +111,13 @@
 #define DMRMMDVM_KEEPALIVE_TIMEOUT      (DMRMMDVM_KEEPALIVE_PERIOD*10)      // in seconds
 #define DMRMMDVM_REFLECTOR_SLOT         DMR_SLOT2
 #define DMRMMDVM_REFLECTOR_COLOUR       1
+
+// G3 Terminal
+#define G3_PRESENCE_PORT                12346                               // UDP port
+#define G3_CONFIG_PORT                  12345                               // UDP port
+#define G3_DV_PORT                      40000                               // UDP port
+#define G3_KEEPALIVE_PERIOD             10                                  // in seconds
+#define G3_KEEPALIVE_TIMEOUT            3600                                // in seconds, 1 hour
 
 // Transcoder server --------------------------------------------
 

--- a/src/main.h
+++ b/src/main.h
@@ -153,6 +153,7 @@
 #define WHITELIST_PATH                  "/xlxd/xlxd.whitelist"
 #define BLACKLIST_PATH                  "/xlxd/xlxd.blacklist"
 #define INTERLINKLIST_PATH              "/xlxd/xlxd.interlink"
+#define TERMINALOPTIONS_PATH            "/xlxd/xlxd.terminal"
 #define DEBUGDUMP_PATH                  "/var/log/xlxd.debug"
 
 // system constants ---------------------------------------------


### PR DESCRIPTION
I implemented a reverse engineered Icom G3 terminal mode for the IC-9700.

Modules are accessed using repeater access from terminal mode, using destination /XRFxxxN.
Modules can be changed on the fly by the client.

Tested in Terminal and AP mode, both using the internal gateway and the external gateway via Icom RS-MS3, and it works as expected.

Since no keepalive is provided by the protocol, it relies on ICMP unreachable received from the client on attempted periodic packet sending, and has a timeout of 1h of inactivity defined in main.h as a safeguard.
