### PR TITLE
Update cysfprotocol.h

### DIFF
--- a/src/cysfprotocol.h
+++ b/src/cysfprotocol.h
@@ -50,7 +50,7 @@
 #define WIRESX_CMD_DISC_REQ         5
 
 // YSF Module ID
-#define YSF_MODULE_ID             'B'
+#define YSF_MODULE_ID             'Y'
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // class


### PR DESCRIPTION
Lets identify the YSF connects with a 'Y' suffix? I do this on my own system and others I look after, and find it very beneficial,
to discern between DMR/D-Star and YSF connects. DMR and D-Star can be sorted by looking at the suffix column (none for DMR),
so doesn't need the same treatment.