### PR TITLE
Allow special callsigns to connect via DMR protocol

### DIFF
--- a/src/ccallsign.cpp
+++ b/src/ccallsign.cpp
@@ -110,22 +110,34 @@ bool CCallsign::IsValid(void) const
         }
     }
     valid &= (iNum < 3);
-    // all remaining char are letter, number or space
+    // all remaining char are letter, number or space (or underscore in extended checks)
     for ( ; i < CALLSIGN_LEN; i++)
     {
+#ifdef EXTENDED_DMRID_CHECKS
+        valid &= IsLetter(m_Callsign[i]) || IsNumber(m_Callsign[i]) || IsSpace(m_Callsign[i]) || IsUnderscore(m_Callsign[i]);
+#else
         valid &= IsLetter(m_Callsign[i]) || IsNumber(m_Callsign[i]) || IsSpace(m_Callsign[i]);
+#endif
     }
     
     // prefix
-    // all chars are number, uppercase or space
+    // all chars are number, uppercase or space (or underscore  in extend checks)
     for ( i = 0; i < CALLSUFFIX_LEN; i++ )
     {
+#ifdef EXTENDED_DMRID_CHECKS
+        valid &= IsLetter(m_Suffix[i]) || IsNumber(m_Suffix[i]) || IsSpace(m_Suffix[i]) || IsUnderscore(m_Suffix[i]);
+#else
         valid &= IsLetter(m_Suffix[i]) || IsNumber(m_Suffix[i]) || IsSpace(m_Suffix[i]);
+#endif
     }
     
     // module
     // is an letter or space
+#ifdef EXTENDED_DMRID_CHECKS
+    valid &= IsLetter(m_Module) || IsSpace(m_Module) || IsNumber(m_Module);
+#else
     valid &= IsLetter(m_Module) || IsSpace(m_Module);
+#endif
     
     // dmrid is not tested, as it can be NULL
     // if station does is not dmr registered
@@ -360,6 +372,13 @@ bool CCallsign::IsLetter(char c) const
 {
     return ((c >= 'A') && (c <= 'Z'));
 }
+
+#ifdef EXTENDED_DMRID_CHECKS
+bool CCallsign::IsUnderscore(char c) const
+{
+    return (c == '_');
+}
+#endif
 
 bool CCallsign::IsSpace(char c) const
 {

--- a/src/ccallsign.h
+++ b/src/ccallsign.h
@@ -85,6 +85,9 @@ protected:
     bool IsNumber(char) const;
     bool IsLetter(char) const;
     bool IsSpace(char) const;
+#ifdef EXTENDED_DMRID_CHECKS
+    bool IsUnderscore(char) const;
+#endif
     
 protected:
     // data

--- a/src/cdmriddir.cpp
+++ b/src/cdmriddir.cpp
@@ -28,6 +28,7 @@
 #include "cdmriddir.h"
 #include "cdmriddirfile.h"
 #include "cdmriddirhttp.h"
+#include "cdmriddirspecial.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // constructor & destructor

--- a/src/cdmriddirspecial.cpp
+++ b/src/cdmriddirspecial.cpp
@@ -1,0 +1,177 @@
+//
+//  cdmriddirspecial.cpp
+//  xlxd
+//
+//  Created by Jean-Luc Deltombe (LX3JL) on 29/12/2017.
+//  Copyright © 2015 Jean-Luc Deltombe (LX3JL). All rights reserved.
+//
+// ----------------------------------------------------------------------------
+//    This file is part of xlxd.
+//
+//    xlxd is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    xlxd is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+// ----------------------------------------------------------------------------
+
+#include <string.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include "main.h"
+#include "cdmriddirfile.h"
+#include "cdmriddirhttp.h"
+#include "cdmriddirspecial.h"
+
+
+#if (EXTENDED_DMRID_CHECKS == 1)
+CDmridDirSpecial g_DmridDirSpecial;
+#endif
+
+////////////////////////////////////////////////////////////////////////////////////////
+// constructor & destructor
+
+CDmridDirSpecial::CDmridDirSpecial()
+{
+}
+
+CDmridDirSpecial::~CDmridDirSpecial()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// init & close
+
+bool CDmridDirSpecial::Init(void)
+{
+    Reload();
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// Reload
+
+bool CDmridDirSpecial::Reload(void)
+{
+    CBuffer buffer;
+    bool ok = false;
+    
+    if ( LoadContent(&buffer) )
+    {   
+        Lock();
+        {
+            ok = RefreshContent(buffer);
+        }
+        Unlock();
+    }   
+    return ok;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// refresh
+
+bool CDmridDirSpecial::LoadContent(CBuffer *buffer)
+{
+    bool ok = false;
+    std::ifstream file;
+    std::streampos size;
+    
+    // open file
+    file.open(SPECIALIDDB_PATH, std::ios::in | std::ios::binary | std::ios::ate);
+    if ( file.is_open() )
+    {
+        // read file
+        size = file.tellg();
+        if ( size > 0 )
+        {
+            // read file into buffer
+            buffer->resize((int)size+1);
+            file.seekg (0, std::ios::beg);
+            file.read((char *)buffer->data(), (int)size);
+            
+            // close file
+            file.close();
+            
+            // update time
+            GetLastModTime(&m_LastModTime);
+            
+            // done
+            ok = true;
+        }
+    }
+    
+    // done
+    return ok;
+}
+
+bool CDmridDirSpecial::RefreshContent(const CBuffer &buffer)
+{
+    bool ok = false;
+    int count = 0;
+    
+    // scan buffer
+    if ( buffer.size() > 0 )
+    {
+        // crack it
+        char *ptr1 = (char *)buffer.data();
+        char *ptr2;
+        
+        // get next line
+        while ( (ptr2 = ::strchr(ptr1, '\n')) != NULL )
+        {
+            *ptr2 = 0;
+            // get items
+            char *dmrid;
+            char *callsign;
+            //std::cout << "Read callsign: " << &callsign << " ID: " << &dmrid << std::endl;
+            if ( ((dmrid = ::strtok(ptr1, ";")) != NULL) && g_DmridDir.IsValidDmrid(dmrid) )
+            {
+                if ( ((callsign = ::strtok(NULL, ";")) != NULL) )
+                {
+                    // new entry
+                    uint32 ui = atoi(dmrid);
+                    CCallsign cs(callsign, ui);
+                    if ( cs.IsValid() )
+                    {
+                        g_DmridDir.m_CallsignMap.insert(std::pair<uint32,CCallsign>(ui, cs));
+                        g_DmridDir.m_DmridMap.insert(std::pair<CCallsign,uint32>(cs,ui));
+                        count++;
+                    }
+                }
+            }
+            // next line
+            ptr1 = ptr2+1;
+        }
+        
+        // done
+        ok = true;
+    }
+    
+    // report
+    std::cout << "Read " << count << " special ids from file " << SPECIALIDDB_PATH << std::endl;
+    
+    // done
+    return ok;
+}
+
+
+bool CDmridDirSpecial::GetLastModTime(time_t *time)
+{
+    bool ok = false;
+    
+    struct stat fileStat;
+    if( ::stat(SPECIALIDDB_PATH, &fileStat) != -1 )
+    {
+        *time = fileStat.st_mtime;
+        ok = true;
+    }
+    return ok;
+}

--- a/src/cdmriddirspecial.h
+++ b/src/cdmriddirspecial.h
@@ -1,8 +1,8 @@
 //
-//  cdmriddir.h
+//  cdmrididirspecial.h
 //  xlxd
 //
-//  Created by Jean-Luc Deltombe (LX3JL) on 08/10/2016.
+//  Created by Jean-Luc Deltombe (LX3JL) on 29/12/2017.
 //  Copyright © 2015 Jean-Luc Deltombe (LX3JL). All rights reserved.
 //
 // ----------------------------------------------------------------------------
@@ -22,76 +22,45 @@
 //    along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 // ----------------------------------------------------------------------------
 
-#ifndef cdmriddir_h
-#define cdmriddir_h
+#ifndef cdmrididirspecial_h
+#define cdmrididirspecial_h
 
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include "cbuffer.h"
-#include "ccallsign.h"
-
-// compare function for std::map::find
-
-struct CDmridDirCallsignCompare
-{
-    bool operator() (const CCallsign &cs1, const CCallsign &cs2) const
-    { return cs1.HasLowerCallsign(cs2);}
-};
-
+#include "cdmriddir.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////
 
-class CDmridDir
+class CDmridDirSpecial
 {
 public:
     // constructor
-    CDmridDir();
+    CDmridDirSpecial();
     
     // destructor
-    ~CDmridDir();
+    ~CDmridDirSpecial();
     
     // init & close
-    virtual bool Init(void);
-    virtual void Close(void);
-    
+    bool Init(void);
+
     // locks
     void Lock(void)                                 { m_Mutex.lock(); }
     void Unlock(void)                               { m_Mutex.unlock(); }
-    
-    // refresh
-    virtual bool LoadContent(CBuffer *)             { return false; }
-    virtual bool RefreshContent(const CBuffer &)    { return false; }
-    
-    // find
-    const CCallsign *FindCallsign(uint32);
-    uint32 FindDmrid(const CCallsign &);
 
-    // validation
-    bool IsValidDmrid(const char *);
-    
-    // data
-    std::map <uint32, CCallsign> m_CallsignMap;
-    std::map <CCallsign, uint32, CDmridDirCallsignCompare> m_DmridMap;
+    // refresh
+    bool LoadContent(CBuffer *);
+    bool RefreshContent(const CBuffer &);
     
 protected:
-    // thread
-    static void Thread(CDmridDir *);
-
     // reload helpers
     bool Reload(void);
-    virtual bool NeedReload(void)                    { return false; }
+    bool GetLastModTime(time_t *);
     
 protected:
+    // data
+    time_t      m_LastModTime;
+
     // Lock()
     std::mutex          m_Mutex;
-           
-    // thread
-    bool                m_bStopThread;
-    std::thread         *m_pThread;
-
-};
+ };
 
 ////////////////////////////////////////////////////////////////////////////////////////
-#endif /* cdmriddir_h */
+#endif /* cdmrididirspecial_h */

--- a/src/creflector.cpp
+++ b/src/creflector.cpp
@@ -28,6 +28,7 @@
 #include "cgatekeeper.h"
 #include "cdmriddirfile.h"
 #include "cdmriddirhttp.h"
+#include "cdmriddirspecial.h"
 #include "ctranscoder.h"
 #include "cysfnodedirfile.h"
 #include "cysfnodedirhttp.h"
@@ -106,6 +107,11 @@ bool CReflector::Start(void)
     
     // init dmrid directory
     g_DmridDir.Init();
+
+#if (EXTENDED_DMRID_CHECKS == 1)
+    // add special ids
+    g_DmridDirSpecial.Init();
+#endif
     
     // init wiresx node directory
     g_YsfNodeDir.Init();

--- a/src/main.h
+++ b/src/main.h
@@ -155,8 +155,9 @@
 
 // Extended DMR ID checks ---------------------------------------
 
-//#define EXTENDED_DMRID_CHECKS                                             // Also allow extended "callsigns" like "IPSC_EU2" 
+//#define EXTENDED_DMRID_CHECKS         1                                   // Also allow extended "callsigns" like "IPSC_EU2" 
                                                                             // used for incoming DMR-DL master connections
+#define SPECIALIDDB_PATH                "/xlxd/specialid.dat"               // File to read special (DMR) IDs from
 
 // Wires-X node database ----------------------------------------
 
@@ -228,6 +229,11 @@ extern CGateKeeper g_GateKeeper;
 #else
     class CYsfNodeDirFile;
     extern CYsfNodeDirFile   g_YsfNodeDir;
+#endif
+
+#if (EXTENDED_DMRID_CHECKS == 1)
+    class CDmridDirSpecial;
+    extern CDmridDirSpecial  g_DmridDirSpecial;
 #endif
 
 class CTranscoder;

--- a/src/main.h
+++ b/src/main.h
@@ -144,6 +144,11 @@
 #define DMRIDDB_PATH                    "/xlxd/dmrid.dat"                   // local file path
 #define DMRIDDB_REFRESH_RATE            180                                 // in minutes
 
+// Extended DMR ID checks ---------------------------------------
+
+//#define EXTENDED_DMRID_CHECKS                                             // Also allow extended "callsigns" like "IPSC_EU2" 
+                                                                            // used for incoming DMR-DL master connections
+
 // Wires-X node database ----------------------------------------
 
 #define YSFNODEDB_USE_RLX_SERVER        1                                   // 1 = use http, 0 = use local file


### PR DESCRIPTION
This allows for connection of IPSC2 masters using callsigns
like IPSC_EU2. In order to not cause issues with the existing code
this has been enclosed into an ifdef. It has to be activated ex-
plicitely though.

The XLX API Server contains "callsigns" and DMR IDs for IPSC2 connects. But those "callsigns" are rejected because they contain an underscore "_" and also a digit at the end. This is considered invalid and thus those links are denied. 

To address this I added some code that can be activated by uncommenting "#define EXTENDED_DMRID_CHECKS" in main.h before compiling. Leaving this commented make the code behave like before.