### PR TITLE
systemd service script for ambed

### DIFF
--- a/scripts/ambed.service
+++ b/scripts/ambed.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=AMBE Transcoder Daemon
+After=network.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+ExecStart=/xlxd/ambed 127.0.0.1
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ambed.service
+++ b/scripts/ambed.service
@@ -6,6 +6,9 @@ After=network.target
 Type=simple
 User=root
 Group=root
+ExecStartPre=-/sbin/rmmod ftdi_sio
+ExecStartPre=-/sbin/rmmod usb_serial
+# Note: adjust /xlxd/ if ambed is installed elsewhere
 ExecStart=/xlxd/ambed 127.0.0.1
 Restart=on-abnormal
 


### PR DESCRIPTION
Here's a systemd service script for starting and stopping ambed without needing to use the run/kill process. Note I'm using /xlxd as the path for ambed rather than /ambed to keep all the files together. I will have a separate pulls coming for a systemd script for xlxd and also one to move ambed to the /xlxd directory.