### PR TITLE
Allows alphanumeric names for the reflector

### DIFF
--- a/dashboard/pgs/class.reflector.php
+++ b/dashboard/pgs/class.reflector.php
@@ -43,10 +43,11 @@ class xReflector {
          fclose($handle);
          
          $this->ServiceName = substr($this->XMLContent, strpos($this->XMLContent, "<XLX")+4, 3);
-         if (!is_numeric($this->ServiceName)) {
-            $this->ServiceName = null;
-            return false;
-         }
+# XLX alphanumeric naming... By commenting the following four lines, it is possible to use an alphanumeric name for the reflector (eg: XLXABC)
+#         if (!is_numeric($this->ServiceName)) {
+#            $this->ServiceName = null;
+#            return false;
+#         }
          
          $this->ReflectorName = "XLX".$this->ServiceName;
          

--- a/dashboard2/pgs/class.reflector.php
+++ b/dashboard2/pgs/class.reflector.php
@@ -61,8 +61,7 @@ class xReflector {
          $tmpNodes          = $XML->GetAllElements($AllNodesString, "NODE");
          
          for ($i=0;$i<count($tmpNodes);$i++) {
-            
-           $Node = new Node($XML->GetElement($tmpNodes[$i], 'Callsign'), $XML->GetElement($tmpNodes[$i], 'IP'), $XML->GetElement($tmpNodes[$i], 'LinkedModule'), $XML->GetElement($tmpNodes[$i], 'Protocol'), $XML->GetElement($tmpNodes[$i], 'ConnectTime'), $XML->GetElement($tmpNodes[$i], 'LastHeardTime'), CreateCode(16));
+             $Node = new Node($XML->GetElement($tmpNodes[$i], 'Callsign'), $XML->GetElement($tmpNodes[$i], 'IP'), $XML->GetElement($tmpNodes[$i], 'LinkedModule'), $XML->GetElement($tmpNodes[$i], 'Protocol'), $XML->GetElement($tmpNodes[$i], 'ConnectTime'), $XML->GetElement($tmpNodes[$i], 'LastHeardTime'), CreateCode(16));
              $this->AddNode($Node);
          }
          

--- a/dashboard2/pgs/class.reflector.php
+++ b/dashboard2/pgs/class.reflector.php
@@ -48,6 +48,7 @@ class xReflector {
 #            $this->ServiceName = null;
 #            return false;
 #         }  
+         
          $this->ReflectorName = "XLX".$this->ServiceName;
          
          $LinkedPeersName = "XLX".$this->ServiceName."  linked peers";
@@ -60,7 +61,8 @@ class xReflector {
          $tmpNodes          = $XML->GetAllElements($AllNodesString, "NODE");
          
          for ($i=0;$i<count($tmpNodes);$i++) {
-             $Node = new Node($XML->GetElement($tmpNodes[$i], 'Callsign'), $XML->GetElement($tmpNodes[$i], 'IP'), $XML->GetElement($tmpNodes[$i], 'LinkedModule'), $XML->GetElement($tmpNodes[$i], 'Protocol'), $XML->GetElement($tmpNodes[$i], 'ConnectTime'), $XML->GetElement($tmpNodes[$i], 'LastHeardTime'), CreateCode(16));
+            
+           $Node = new Node($XML->GetElement($tmpNodes[$i], 'Callsign'), $XML->GetElement($tmpNodes[$i], 'IP'), $XML->GetElement($tmpNodes[$i], 'LinkedModule'), $XML->GetElement($tmpNodes[$i], 'Protocol'), $XML->GetElement($tmpNodes[$i], 'ConnectTime'), $XML->GetElement($tmpNodes[$i], 'LastHeardTime'), CreateCode(16));
              $this->AddNode($Node);
          }
          

--- a/dashboard2/pgs/class.reflector.php
+++ b/dashboard2/pgs/class.reflector.php
@@ -48,7 +48,7 @@ class xReflector {
 #            $this->ServiceName = null;
 #            return false;
 #         }  
-         
+#         
          $this->ReflectorName = "XLX".$this->ServiceName;
          
          $LinkedPeersName = "XLX".$this->ServiceName."  linked peers";

--- a/dashboard2/pgs/class.reflector.php
+++ b/dashboard2/pgs/class.reflector.php
@@ -43,11 +43,11 @@ class xReflector {
          fclose($handle);
          
          $this->ServiceName = substr($this->XMLContent, strpos($this->XMLContent, "<XLX")+4, 3);
-         if (!is_numeric($this->ServiceName)) {
-            $this->ServiceName = null;
-            return false;
-         }
-         
+# XLX alphanumeric naming... By commenting the following four lines, it is possible to use an alphanumeric name for the reflector (eg: XLXABC)          
+#         if (!is_numeric($this->ServiceName)) {
+#            $this->ServiceName = null;
+#            return false;
+#         }  
          $this->ReflectorName = "XLX".$this->ServiceName;
          
          $LinkedPeersName = "XLX".$this->ServiceName."  linked peers";


### PR DESCRIPTION
Good morning Luc.

I have changes the reflector_class.php files both in dashboard and dashboard2 in order to allow alphanumeric names for the reflector. 

Please proecess this pull request

Thank you,
Catalin