### PR TITLE
Avoid using public IP for transcoder connection

### DIFF
--- a/src/ccodecstream.cpp
+++ b/src/ccodecstream.cpp
@@ -99,7 +99,7 @@ bool CCodecStream::Init(uint16 uiPort)
     m_uiPort = uiPort;
     
     // create our socket
-    ok = m_Socket.Open(uiPort);
+    ok = m_Socket.Open(CIp("0.0.0.0"), uiPort);
     if ( ok )
     {
         // start  thread;

--- a/src/ctranscoder.cpp
+++ b/src/ctranscoder.cpp
@@ -97,7 +97,7 @@ bool CTranscoder::Init(void)
     m_Ip = g_Reflector.GetTranscoderIp();
     
     // create our socket
-    ok = m_Socket.Open(TRANSCODER_PORT);
+    ok = m_Socket.Open(CIp("0.0.0.0"), TRANSCODER_PORT);
     if ( ok )
     {
         // start  thread;

--- a/src/cudpsocket.cpp
+++ b/src/cudpsocket.cpp
@@ -52,6 +52,11 @@ CUdpSocket::~CUdpSocket()
 
 bool CUdpSocket::Open(uint16 uiPort)
 {
+    return Open(g_Reflector.GetListenIp(), uiPort);
+}
+
+bool CUdpSocket::Open(const CIp & listenIp, uint16 uiPort)
+{
     bool open = false;
     
     // create socket
@@ -62,7 +67,7 @@ bool CUdpSocket::Open(uint16 uiPort)
         ::memset(&m_SocketAddr, 0, sizeof(struct sockaddr_in));
         m_SocketAddr.sin_family = AF_INET;
         m_SocketAddr.sin_port = htons(uiPort);
-        m_SocketAddr.sin_addr.s_addr = inet_addr(g_Reflector.GetListenIp());
+        m_SocketAddr.sin_addr.s_addr = inet_addr(listenIp);
         
         if ( bind(m_Socket, (struct sockaddr *)&m_SocketAddr, sizeof(struct sockaddr_in)) == 0 )
         {

--- a/src/cudpsocket.h
+++ b/src/cudpsocket.h
@@ -56,6 +56,7 @@ public:
     
     // open & close
     bool Open(uint16);
+    bool Open(const CIp &, uint16);
     void Close(void);
     int  GetSocket(void)        { return m_Socket; }
     


### PR DESCRIPTION
Hi,

The public reflector IP is used as source IP for communication with the transcoder. This causes some issues on some systems with peeky firewalls.
This aims to solve this.
By using 0.0.0.0 when opening the socket the "best" address will be used to reach the transcoder.

73
Geoffrey F4FXL / KC3FRA

