### PR TITLE
Update buffer allocation to the correct size

### DIFF
--- a/src/crawsocket.cpp
+++ b/src/crawsocket.cpp
@@ -92,7 +92,7 @@ int CRawSocket::Receive(CBuffer *Buffer, CIp *Ip, int timeout)
     if ( m_Socket != -1 )
     {
         // allocate buffer
-        Buffer->resize(UDP_BUFFER_LENMAX);
+        Buffer->resize(RAW_BUFFER_LENMAX);
 
         // control socket
         FD_ZERO(&FdSet);


### PR DESCRIPTION
Maximum size of ICMP packet is 64k while buffer allocation was UDP_BUFFER_LENMAX, while read was up to 64k.
This will cause a crash on read in the subsequent read for packets with length greater than UDP_BUFFER_LENMAX via a buffer overflow.