### PR TITLE
customizable datetime format

### DIFF
--- a/dashboard/pgs/config.inc.php
+++ b/dashboard/pgs/config.inc.php
@@ -52,6 +52,10 @@ $PageOptions['IRCDDB']['Show']                       = true;        // Show live
 
 $PageOptions['CustomTXT']                            = '';					// custom text in your header   
 
+$PageOptions['DateFormat']                           = 'd.m.Y H:i';  // Date format for LastHeard column
+$PageOptions['LastHeardTZ']                          = '';           // Arbitrary text after "Last Heard" column header
+
+
 $Service['PIDFile']                                  = '/var/log/xlxd.pid';
 $Service['XMLFile']                                  = '/var/log/xlxd.xml';
 

--- a/dashboard/pgs/users.php
+++ b/dashboard/pgs/users.php
@@ -93,7 +93,7 @@ if ($PageOptions['UserPage']['ShowFilter']) {
    <th>Suffix</th>
    <th>DPRS</th>
    <th>Via / Peer</th>
-   <th>Last heard</th>
+   <th>Last heard<?php echo $PageOptions['LastHeardTZ'];?></th>
    <th align="center" valign="middle"><img src="./img/ear.png" alt="Listening on" /></th>
  </tr><?php
 
@@ -148,7 +148,7 @@ for ($i=0;$i<$Reflector->StationCount();$i++) {
          echo ' / '.$Reflector->Stations[$i]->GetPeer();
       }
       echo '</td>
-   <td width="150">'.@date("d.m.Y H:i", $Reflector->Stations[$i]->GetLastHeardTime()).'</td>
+   <td width="150">'.@date($PageOptions['DateFormat'], $Reflector->Stations[$i]->GetLastHeardTime()).'</td>
    <td align="center" width="30">'.$Reflector->Stations[$i]->GetModule().'</td>
  </tr>';
    }


### PR DESCRIPTION
This pull adds customization options to config.inc.php to customize the timestamp format in the LastHeard column and add a spot to put a label on the header column to specify the local timezone.