### PR TITLE
Avoid using public IP address to listen to ambed

### DIFF
--- a/scripts/xlxd
+++ b/scripts/xlxd
@@ -20,6 +20,8 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 NAME="xlxd"
 DAEMON="/xlxd/xlxd"
 ARGUMENTS="XLX999 192.168.1.240 127.0.0.1"
+#Case where ambed runs on another host and you want to use another IP to talk to it. Here ambed is on 10.9.0.100 and 10.9.0.1 is used to talk to it
+#ARGUMENTS="XLX999 192.168.1.240 10.9.0.100 10.9.0.1
 PIDFILE="/var/log/xlxd.pid"
 USER=root
 GROUP=root

--- a/scripts/xlxd
+++ b/scripts/xlxd
@@ -20,8 +20,6 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 NAME="xlxd"
 DAEMON="/xlxd/xlxd"
 ARGUMENTS="XLX999 192.168.1.240 127.0.0.1"
-#Case where ambed runs on another host and you want to use another IP to talk to it. Here ambed is on 10.9.0.100 and 10.9.0.1 is used to talk to it
-#ARGUMENTS="XLX999 192.168.1.240 10.9.0.100 10.9.0.1
 PIDFILE="/var/log/xlxd.pid"
 USER=root
 GROUP=root

--- a/src/ccodecstream.cpp
+++ b/src/ccodecstream.cpp
@@ -99,7 +99,7 @@ bool CCodecStream::Init(uint16 uiPort)
     m_uiPort = uiPort;
     
     // create our socket
-    ok = m_Socket.Open(uiPort);
+    ok = m_Socket.Open(CIp("0.0.0.0"), uiPort);
     if ( ok )
     {
         // start  thread;

--- a/src/ccodecstream.cpp
+++ b/src/ccodecstream.cpp
@@ -97,9 +97,10 @@ bool CCodecStream::Init(uint16 uiPort)
     // create server's IP
     m_Ip = g_Reflector.GetTranscoderIp();
     m_uiPort = uiPort;
+    CIp interfaceIp = g_Reflector.GetTranscoderInterfaceIp();
     
     // create our socket
-    ok = m_Socket.Open(CIp("0.0.0.0"), uiPort);
+    ok = m_Socket.Open(interfaceIp, uiPort);
     if ( ok )
     {
         // start  thread;

--- a/src/ccodecstream.cpp
+++ b/src/ccodecstream.cpp
@@ -97,10 +97,9 @@ bool CCodecStream::Init(uint16 uiPort)
     // create server's IP
     m_Ip = g_Reflector.GetTranscoderIp();
     m_uiPort = uiPort;
-    CIp interfaceIp = g_Reflector.GetTranscoderInterfaceIp();
     
     // create our socket
-    ok = m_Socket.Open(interfaceIp, uiPort);
+    ok = m_Socket.Open(CIp("0.0.0.0"), uiPort);
     if ( ok )
     {
         // start  thread;

--- a/src/ccodecstream.cpp
+++ b/src/ccodecstream.cpp
@@ -99,7 +99,7 @@ bool CCodecStream::Init(uint16 uiPort)
     m_uiPort = uiPort;
     
     // create our socket
-    ok = m_Socket.Open(CIp("0.0.0.0"), uiPort);
+    ok = m_Socket.Open(g_Reflector.GetTranscoderLocalIp(), uiPort);
     if ( ok )
     {
         // start  thread;

--- a/src/cip.h
+++ b/src/cip.h
@@ -53,6 +53,9 @@ public:
     // operator
     bool operator ==(const CIp &) const;
     operator const char *() const;
+
+    // Factory
+    static void GetLocalIp(const CIp & remoteIp, const CIp & defaultLocalIp, CIp & localIp);
     
 protected:
     // data

--- a/src/creflector.h
+++ b/src/creflector.h
@@ -59,8 +59,10 @@ public:
     const CCallsign &GetCallsign(void) const        { return m_Callsign; }
     void SetListenIp(const CIp &ip)                 { m_Ip = ip; }
     void SetTranscoderIp(const CIp &ip)             { m_AmbedIp = ip; }
+    void SetTranscoderInterfaceIp(const CIp &ip)    { m_AmbedInterfaceIp = ip; }
     const CIp &GetListenIp(void) const              { return m_Ip; }
     const CIp &GetTranscoderIp(void) const          { return m_AmbedIp; }
+    const CIp &GetTranscoderInterfaceIp(void) const { return m_AmbedInterfaceIp; }
     
     // operation
     bool Start(void);
@@ -121,6 +123,7 @@ protected:
     CCallsign       m_Callsign;
     CIp             m_Ip;
     CIp             m_AmbedIp;
+    CIp             m_AmbedInterfaceIp;//Ip used ot talk to ambed IP
     
     // objects
     CUsers          m_Users;            // sorted list of lastheard stations

--- a/src/creflector.h
+++ b/src/creflector.h
@@ -59,8 +59,10 @@ public:
     const CCallsign &GetCallsign(void) const        { return m_Callsign; }
     void SetListenIp(const CIp &ip)                 { m_Ip = ip; }
     void SetTranscoderIp(const CIp &ip)             { m_AmbedIp = ip; }
+    void SetTranscoderLocalIp(const CIp &ip)        { m_AmbedLocalIp = ip; }
     const CIp &GetListenIp(void) const              { return m_Ip; }
     const CIp &GetTranscoderIp(void) const          { return m_AmbedIp; }
+    const CIp &GetTranscoderLocalIp(void) const     { return m_AmbedLocalIp; }
     
     // operation
     bool Start(void);
@@ -121,6 +123,7 @@ protected:
     CCallsign       m_Callsign;
     CIp             m_Ip;
     CIp             m_AmbedIp;
+    CIp             m_AmbedLocalIp;
     
     // objects
     CUsers          m_Users;            // sorted list of lastheard stations

--- a/src/creflector.h
+++ b/src/creflector.h
@@ -59,10 +59,8 @@ public:
     const CCallsign &GetCallsign(void) const        { return m_Callsign; }
     void SetListenIp(const CIp &ip)                 { m_Ip = ip; }
     void SetTranscoderIp(const CIp &ip)             { m_AmbedIp = ip; }
-    void SetTranscoderInterfaceIp(const CIp &ip)    { m_AmbedInterfaceIp = ip; }
     const CIp &GetListenIp(void) const              { return m_Ip; }
     const CIp &GetTranscoderIp(void) const          { return m_AmbedIp; }
-    const CIp &GetTranscoderInterfaceIp(void) const { return m_AmbedInterfaceIp; }
     
     // operation
     bool Start(void);
@@ -123,7 +121,6 @@ protected:
     CCallsign       m_Callsign;
     CIp             m_Ip;
     CIp             m_AmbedIp;
-    CIp             m_AmbedInterfaceIp;//Ip used ot talk to ambed IP
     
     // objects
     CUsers          m_Users;            // sorted list of lastheard stations

--- a/src/ctranscoder.cpp
+++ b/src/ctranscoder.cpp
@@ -97,7 +97,7 @@ bool CTranscoder::Init(void)
     m_Ip = g_Reflector.GetTranscoderIp();
     
     // create our socket
-    ok = m_Socket.Open(TRANSCODER_PORT);
+    ok = m_Socket.Open(CIp("0.0.0.0"), TRANSCODER_PORT);
     if ( ok )
     {
         // start  thread;

--- a/src/ctranscoder.cpp
+++ b/src/ctranscoder.cpp
@@ -95,9 +95,11 @@ bool CTranscoder::Init(void)
 
     // create server's IP
     m_Ip = g_Reflector.GetTranscoderIp();
+    CIp interfaceIp = g_Reflector.GetTranscoderInterfaceIp();
+
     
     // create our socket
-    ok = m_Socket.Open(CIp("0.0.0.0"), TRANSCODER_PORT);
+    ok = m_Socket.Open(interfaceIp, TRANSCODER_PORT);
     if ( ok )
     {
         // start  thread;
@@ -105,7 +107,7 @@ bool CTranscoder::Init(void)
     }
     else
     {
-        std::cout << "Error opening socket on port UDP" << TRANSCODER_PORT << " on ip " << g_Reflector.GetListenIp() << std::endl;
+        std::cout << "Transcoder Error opening socket on port UDP" << TRANSCODER_PORT << " on ip " << g_Reflector.GetListenIp() << std::endl;
     }
 
     // done

--- a/src/ctranscoder.cpp
+++ b/src/ctranscoder.cpp
@@ -95,11 +95,9 @@ bool CTranscoder::Init(void)
 
     // create server's IP
     m_Ip = g_Reflector.GetTranscoderIp();
-    CIp interfaceIp = g_Reflector.GetTranscoderInterfaceIp();
-
     
     // create our socket
-    ok = m_Socket.Open(interfaceIp, TRANSCODER_PORT);
+    ok = m_Socket.Open(CIp("0.0.0.0"), TRANSCODER_PORT);
     if ( ok )
     {
         // start  thread;
@@ -107,7 +105,7 @@ bool CTranscoder::Init(void)
     }
     else
     {
-        std::cout << "Transcoder Error opening socket on port UDP" << TRANSCODER_PORT << " on ip " << g_Reflector.GetListenIp() << std::endl;
+        std::cout << "Error opening socket on port UDP" << TRANSCODER_PORT << " on ip " << g_Reflector.GetListenIp() << std::endl;
     }
 
     // done

--- a/src/ctranscoder.cpp
+++ b/src/ctranscoder.cpp
@@ -97,7 +97,7 @@ bool CTranscoder::Init(void)
     m_Ip = g_Reflector.GetTranscoderIp();
     
     // create our socket
-    ok = m_Socket.Open(CIp("0.0.0.0"), TRANSCODER_PORT);
+    ok = m_Socket.Open(g_Reflector.GetTranscoderLocalIp(), TRANSCODER_PORT);
     if ( ok )
     {
         // start  thread;

--- a/src/cudpsocket.cpp
+++ b/src/cudpsocket.cpp
@@ -52,6 +52,11 @@ CUdpSocket::~CUdpSocket()
 
 bool CUdpSocket::Open(uint16 uiPort)
 {
+    return Open(g_Reflector.GetListenIp(), uiPort);
+}
+
+bool CUdpSocket::Open(const CIp & listenIp, uint16 uiPort)
+{
     bool open = false;
     
     // create socket
@@ -62,7 +67,7 @@ bool CUdpSocket::Open(uint16 uiPort)
         ::memset(&m_SocketAddr, 0, sizeof(struct sockaddr_in));
         m_SocketAddr.sin_family = AF_INET;
         m_SocketAddr.sin_port = htons(uiPort);
-        m_SocketAddr.sin_addr.s_addr = inet_addr(g_Reflector.GetListenIp());
+        m_SocketAddr.sin_addr.s_addr = inet_addr(listenIp);
         
         if ( bind(m_Socket, (struct sockaddr *)&m_SocketAddr, sizeof(struct sockaddr_in)) == 0 )
         {

--- a/src/cudpsocket.h
+++ b/src/cudpsocket.h
@@ -56,6 +56,7 @@ public:
     
     // open & close
     bool Open(uint16);
+    bool Open(const CIp &, uint16);
     void Close(void);
     int  GetSocket(void)        { return m_Socket; }
     

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,10 +87,11 @@ int main(int argc, const char * argv[])
 #endif
 
     // check arguments
-    if ( argc != 4 )
+    if ( argc < 4 || argc > 5)
     {
-        std::cout << "Usage: xlxd callsign xlxdip ambedip" << std::endl;
-        std::cout << "example: xlxd XLX999 192.168.178.212 127.0.0.1" << std::endl;
+        std::cout << "Usage: xlxd callsign xlxdip ambedip [interface_to_reach_ambed] " << std::endl;
+        std::cout << "example (ambed running locally): xlxd XLX999 192.168.178.212 127.0.0.1" << std::endl;
+        std::cout << "example (ambed running on another host): xlxd XLX999 192.168.178.212 10.9.0.100 10.9.0.1" << std::endl;
         return 1;
     }
 
@@ -101,6 +102,7 @@ int main(int argc, const char * argv[])
     g_Reflector.SetCallsign(argv[1]);
     g_Reflector.SetListenIp(CIp(argv[2]));
     g_Reflector.SetTranscoderIp(CIp(CIp(argv[3])));
+    g_Reflector.SetTranscoderInterfaceIp(CIp(argv[argc == 5 ? 4 : 2]));
   
     // and let it run
     if ( !g_Reflector.Start() )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,8 +99,19 @@ int main(int argc, const char * argv[])
 
     // initialize reflector
     g_Reflector.SetCallsign(argv[1]);
-    g_Reflector.SetListenIp(CIp(argv[2]));
-    g_Reflector.SetTranscoderIp(CIp(CIp(argv[3])));
+
+    CIp listenIp = CIp(argv[2]);
+    CIp localTranscoderIp = CIp(listenIp);
+    CIp transcoderIp = CIp(argv[3]);
+
+    if(transcoderIp.GetAddr() != CIp("127.0.0.1").GetAddr())
+    {
+        CIp::GetLocalIp(transcoderIp, listenIp, localTranscoderIp);
+    }
+
+    g_Reflector.SetListenIp(listenIp);
+    g_Reflector.SetTranscoderIp(transcoderIp);
+    g_Reflector.SetTranscoderLocalIp(localTranscoderIp);
   
     // and let it run
     if ( !g_Reflector.Start() )
@@ -109,7 +120,9 @@ int main(int argc, const char * argv[])
         exit(EXIT_FAILURE);
     }
     std::cout << "Reflector " << g_Reflector.GetCallsign()
-              << "started and listening on " << g_Reflector.GetListenIp() << std::endl;
+              << "started and listening on " << g_Reflector.GetListenIp() << std::endl
+              << "Listening for ambed " << g_Reflector.GetTranscoderIp()
+              << " on " << g_Reflector.GetTranscoderLocalIp() << std::endl;
     
 #ifdef RUN_AS_DAEMON
 	// run forever

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,11 +87,10 @@ int main(int argc, const char * argv[])
 #endif
 
     // check arguments
-    if ( argc < 4 || argc > 5)
+    if ( argc != 4 )
     {
-        std::cout << "Usage: xlxd callsign xlxdip ambedip [interface_to_reach_ambed] " << std::endl;
-        std::cout << "example (ambed running locally): xlxd XLX999 192.168.178.212 127.0.0.1" << std::endl;
-        std::cout << "example (ambed running on another host): xlxd XLX999 192.168.178.212 10.9.0.100 10.9.0.1" << std::endl;
+        std::cout << "Usage: xlxd callsign xlxdip ambedip" << std::endl;
+        std::cout << "example: xlxd XLX999 192.168.178.212 127.0.0.1" << std::endl;
         return 1;
     }
 
@@ -102,7 +101,6 @@ int main(int argc, const char * argv[])
     g_Reflector.SetCallsign(argv[1]);
     g_Reflector.SetListenIp(CIp(argv[2]));
     g_Reflector.SetTranscoderIp(CIp(CIp(argv[3])));
-    g_Reflector.SetTranscoderInterfaceIp(CIp(argv[argc == 5 ? 4 : 2]));
   
     // and let it run
     if ( !g_Reflector.Start() )


### PR DESCRIPTION
Hi,

As per the discussion on https://github.com/LX3JL/xlxd/pull/176 I did following :
~~It is possible to specify an optional  IP which is used to talk to ambed when  it is running on another host. If left out, behavior is same as before.~~
The most suitable localIP to talk to ambed is automatically determined. If xlxd is told that ambed is on 127.0.0.1 then the public IP is used i.e. all is like used to be.