### PR TITLE
Add "Modules list" page

### DIFF
--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -138,7 +138,8 @@ else {
                <td><a href="./index.php" class="menulink<?php if ($_GET['show'] == '') { echo 'active'; } ?>">Users / Modules</a></td>
                <td><a href="./index.php?show=repeaters" class="menulink<?php if ($_GET['show'] == 'repeaters') { echo 'active'; } ?>">Repeaters / Nodes (<?php echo $Reflector->NodeCount(); ?>)</a></td>
                <td><a href="./index.php?show=peers" class="menulink<?php if ($_GET['show'] == 'peers') { echo 'active'; } ?>">Peers (<?php echo $Reflector->PeerCount(); ?>)</a></td>
-               <td><a href="./index.php?show=reflectors" class="menulink<?php if ($_GET['show'] == 'reflectors') { echo 'active'; } ?>">Reflectorlist</a></td>
+               <td><a href="./index.php?show=modules" class="menulink<?php if ($_GET['show'] == 'modules') { echo 'active'; } ?>">Modules list</a></td>
+               <td><a href="./index.php?show=reflectors" class="menulink<?php if ($_GET['show'] == 'reflectors') { echo 'active'; } ?>">Reflectors list</a></td>
                <?php
                
                if ($PageOptions['Traffic']['Show']) {
@@ -176,6 +177,7 @@ else {
       case 'repeaters'  : require_once("./pgs/repeaters.php"); break;
       case 'liveircddb' : require_once("./pgs/liveircddb.php"); break;
       case 'peers'      : require_once("./pgs/peers.php"); break;
+      case 'modules'    : require_once("./pgs/modules.php"); break;
       case 'reflectors' : require_once("./pgs/reflectors.php"); break;
       case 'traffic'		: require_once("./pgs/traffic.php"); break;
       default           : require_once("./pgs/users.php");

--- a/dashboard/pgs/config.inc.php
+++ b/dashboard/pgs/config.inc.php
@@ -22,6 +22,8 @@ $PageOptions['DashboardVersion']                     = '2.4.1';		// Dashboard Ve
 $PageOptions['PageRefreshActive']                    = true;		// Activate automatic refresh
 $PageOptions['PageRefreshDelay']                     = '10000';		// Page refresh time in miliseconds
 
+$PageOptions['NumberOfModules']                      = 10;		// Number of Modules enabled on reflector
+
 $PageOptions['RepeatersPage'] = array();
 $PageOptions['RepeatersPage']['LimitTo']             = 99;		// Number of Repeaters to show
 $PageOptions['RepeatersPage']['IPModus']             = 'ShowFullIP';	// See possible options above

--- a/dashboard/pgs/modules.php
+++ b/dashboard/pgs/modules.php
@@ -1,0 +1,49 @@
+<table class="listingtable">
+ <tr>
+   <th width="80" rowspan="2">Module</th>
+   <th width="130" rowspan="2">Name</th>
+   <th width="65" rowspan="2">Users</th>
+   <th colspan="2">DPlus</th>
+   <th colspan="2">DExtra</th>
+   <th colspan="2">DCS</th>
+   <th width="65" rowspan="2">DMR</th>
+ </tr>
+ <tr>
+   <th width="100">URCALL</th>
+   <th width="100">DTMF</th>
+   <th width="100">URCALL</th>
+   <th width="100">DTMF</th>
+   <th width="100">URCALL</th>
+   <th width="100">DTMF</th>
+ </tr>
+<?php
+
+$ReflectorNumber = substr($Reflector->GetReflectorName(), 3, 3);
+$NumberOfModules = isset($PageOptions['NumberOfModules']) ? min(max($PageOptions['NumberOfModules'],0),26) : 26;
+
+$odd = "";
+
+for ($i = 1; $i <= $NumberOfModules; $i++) {
+
+   $module = chr(ord('A')+($i-1));
+
+   if ($odd == "#FFFFFF") { $odd = "#F1FAFA"; } else { $odd = "#FFFFFF"; }
+
+   echo '
+ <tr height="30" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
+   <td align="center">'. $module .'</td>
+   <td align="center">'. (empty($PageOptions['ModuleNames'][$module]) ? '-' : $PageOptions['ModuleNames'][$module]) .'</td>
+   <td align="center">'. count($Reflector->GetNodesInModulesByID($module)) .'</td>
+   <td align="center">'. 'REF' . $ReflectorNumber . $module . 'L' .'</td>
+   <td align="center">'. (is_numeric($ReflectorNumber) ? '*' . sprintf('%01d',$ReflectorNumber) . (($i<=4)?$module:sprintf('%02d',$i)) : '-') .'</td>
+   <td align="center">'. 'XRF' . $ReflectorNumber . $module . 'L' .'</td>
+   <td align="center">'. (is_numeric($ReflectorNumber) ? 'B' . sprintf('%01d',$ReflectorNumber) . (($i<=4)?$module:sprintf('%02d',$i)) : '-') .'</td>
+   <td align="center">'. 'DCS' . $ReflectorNumber . $module . 'L' .'</td>
+   <td align="center">'. (is_numeric($ReflectorNumber) ? 'D' . sprintf('%01d',$ReflectorNumber) . (($i<=4)?$module:sprintf('%02d',$i)) : '-') .'</td>
+   <td align="center">'. (4000+$i) .'</td>
+ </tr>';
+}
+
+?>
+
+</table>


### PR DESCRIPTION
This patch adds a new page on dashboard to list all modules with its names from config.inc.php (helpful to know module names even for modules with no users connected) and eventually useful info for users on how to link them.