### PR TITLE
fix dplus sending header packets inconsistently

### DIFF
--- a/src/cdplusprotocol.cpp
+++ b/src/cdplusprotocol.cpp
@@ -315,7 +315,7 @@ void CDplusProtocol::HandleQueue(void)
                          m_Socket.Send(buffer, client->GetIp());
 
                         // is it time to insert a DVheader copy ?
-                        if ( (m_StreamsCache[iModId].m_iSeqCounter++ % 21) == 20 )
+                        if ( (m_StreamsCache[iModId].m_iSeqCounter % 21) == 20 )
                         {
                             // yes, clone it
                             CDvHeaderPacket packet2(m_StreamsCache[iModId].m_dvHeader);
@@ -333,6 +333,10 @@ void CDplusProtocol::HandleQueue(void)
             g_Reflector.ReleaseClients();
         }
         
+        if ( packet->IsDvFrame() )
+        {
+            m_StreamsCache[iModId].m_iSeqCounter++;
+        }
         
         // done
         delete packet;


### PR DESCRIPTION
This patch fixes dplus sending header packets at wrong frequency, depending on the number of dplus clients connected on the reflector, as m_iSeqCounter was being wrongly incremented for each client that each dv packet is sent and not just per-packet, in some cases (for eg. with 3 or 7 clients connected) only one client could actually get lots of header packets and the other clients get none.