### PR TITLE
allow connecting dextra clients to listen already streaming clients

### DIFF
--- a/src/cdextraprotocol.h
+++ b/src/cdextraprotocol.h
@@ -55,6 +55,15 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 // class
 
+class CDextraStreamCacheItem
+{
+public:
+    CDextraStreamCacheItem()     {}
+    ~CDextraStreamCacheItem()    {}
+    
+    CDvHeaderPacket m_dvHeader;
+};
+
 class CDextraProtocol : public CProtocol
 {
 public:
@@ -101,6 +110,9 @@ protected:
 protected:
     // time
     CTimePoint          m_LastKeepaliveTime;
+    
+    // for queue header caches
+    std::array<CDextraStreamCacheItem, NB_OF_MODULES>    m_StreamsCache;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch adds code to cache header packets on dextra protocol code (similarly to how it is already done for dplus and dcs) and when new dextra clients connect to the reflector, if there is any other client already streaming on the module, send a copy of the cached header packet to the connecting client (right after Ack), so it can properly listen the already streaming client.