### PR TITLE
add IPv6 support for xlxd-2.5.x

### DIFF
--- a/dashboard2/pgs/repeaters.php
+++ b/dashboard2/pgs/repeaters.php
@@ -60,14 +60,35 @@ for ($i=0;$i<$Reflector->NodeCount();$i++) {
    if ($PageOptions['RepeatersPage']['IPModus'] != 'HideIP') {
       echo '
    <td>';
-      $Bytes = explode(".", $Reflector->Nodes[$i]->GetIP());
-      if ($Bytes !== false && count($Bytes) == 4) {
-         switch ($PageOptions['RepeatersPage']['IPModus']) {
-            case 'ShowLast1ByteOfIP'      : echo $PageOptions['RepeatersPage']['MasqueradeCharacter'].'.'.$PageOptions['RepeatersPage']['MasqueradeCharacter'].'.'.$PageOptions['RepeatersPage']['MasqueradeCharacter'].'.'.$Bytes[3]; break;
-            case 'ShowLast2ByteOfIP'      : echo $PageOptions['RepeatersPage']['MasqueradeCharacter'].'.'.$PageOptions['RepeatersPage']['MasqueradeCharacter'].'.'.$Bytes[2].'.'.$Bytes[3]; break;
-            case 'ShowLast3ByteOfIP'      : echo $PageOptions['RepeatersPage']['MasqueradeCharacter'].'.'.$Bytes[1].'.'.$Bytes[2].'.'.$Bytes[3]; break;
-            default                       : echo $Reflector->Nodes[$i]->GetIP();
-         }
+      $IPBinary = inet_pton($Reflector->Nodes[$i]->GetIP());
+      $IPLength = strlen($IPBinary);
+      $Bytes = str_split($IPBinary, 1);
+      switch ($PageOptions['RepeatersPage']['IPModus']) {
+         case 'ShowLast1ByteOfIP' : $MasqByte = 3; break;
+         case 'ShowLast2ByteOfIP' : $MasqByte = 2; break;
+         case 'ShowLast3ByteOfIP' : $MasqByte = 1; break;
+         default                  : $MasqByte = 0; break;
+      }
+      switch ($IPLength) {
+         case 4:
+            for ($pos = 0; $pos < $IPLength; $pos++) {
+               if ($pos) echo '.';
+               if ($pos < $MasqByte) echo $PageOptions['RepeatersPage']['MasqueradeCharacter'];
+               else echo ord($Bytes[$pos]);
+            }
+            break;
+         case 16:
+            for ($pos = 0; $pos < $IPLength; $pos += 2) {
+               if ($pos) echo ':';
+               if ($pos < ($MasqByte * 4)) echo $PageOptions['RepeatersPage']['MasqueradeCharacter'];
+               else {
+                  echo bin2hex($Bytes[$pos]);
+                  echo bin2hex($Bytes[$pos + 1]);
+               }
+            }
+            break;
+         default:
+            break;
       }
       echo '</td>';
    }

--- a/src/cdmriddir.cpp
+++ b/src/cdmriddir.cpp
@@ -152,7 +152,10 @@ bool CDmridDir::IsValidDmrid(const char *sz)
         ok = true;
         for ( size_t i = 0; (i < n) && ok; i++ )
         {
-            ok &= ::isdigit(sz[i]);
+            if ( !::isdigit(sz[i]) )
+            {
+                ok = false;
+            }
         }
     }
     return ok;

--- a/src/cdmrmmdvmprotocol.cpp
+++ b/src/cdmrmmdvmprotocol.cpp
@@ -70,9 +70,8 @@ bool CDmrmmdvmProtocol::Init(void)
     m_LastKeepaliveTime.Now();
     
     // random number generator
-    time_t t;
-    ::srand((unsigned) time(&t));
-    m_uiAuthSeed = (uint32)rand();
+    std::random_device rd;
+    m_uiAuthSeed = rd();
     
     // done
     return ok;

--- a/src/cdmrplusprotocol.h
+++ b/src/cdmrplusprotocol.h
@@ -83,8 +83,8 @@ protected:
     // packet decoding helpers
     bool IsValidConnectPacket(const CBuffer &, CCallsign *, char *, const CIp &);
     bool IsValidDisconnectPacket(const CBuffer &, CCallsign *, char *);
-    bool IsValidDvHeaderPacket(const CIp &, const CBuffer &, CDvHeaderPacket **);
-    bool IsValidDvFramePacket(const CIp &, const CBuffer &, CDvFramePacket **);
+    bool IsValidDvHeaderPacket(const CBuffer &, CDvHeaderPacket **);
+    bool IsValidDvFramePacket(const CBuffer &, CDvFramePacket **);
     
     // packet encoding helpers
     void EncodeConnectAckPacket(CBuffer *);
@@ -102,7 +102,7 @@ protected:
     uint32 ModuleToDmrDestId(char) const;
     
     // uiStreamId helpers
-    uint32 IpToStreamId(const CIp &) const;
+    uint32 CreateStreamId(void) const;
     
     // Buffer & LC helpers
     void AppendVoiceLCToBuffer(CBuffer *, uint32) const;
@@ -116,6 +116,9 @@ protected:
     
     // for queue header caches
     std::array<CDmrplusStreamCacheItem, NB_OF_MODULES>    m_StreamsCache;
+    
+    // random number generator
+    mutable std::mt19937 m_Random;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cg3protocol.cpp
+++ b/src/cg3protocol.cpp
@@ -621,7 +621,7 @@ bool CG3Protocol::OnDvHeaderPacketIn(CDvHeaderPacket *Header, const CIp &Ip)
                         // drop if invalid module
                         delete Header;
                         g_Reflector.ReleaseClients();
-                        return NULL;
+                        return false;
                     }
                 }
 

--- a/src/cip.cpp
+++ b/src/cip.cpp
@@ -31,46 +31,66 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 // constructors
 
-CIp::CIp()
+CIp::CIp(const int af)
 {
-    ::memset(&m_Addr, 0, sizeof(m_Addr));
-    m_Addr.sin_family = AF_INET;
+    ::memset(&m_Addr, 0, m_AddrLen = sizeof(struct sockaddr_in));
+    m_Addr.ss_family = af;
 }
 
 CIp::CIp(const char *sz)
 {
-    ::memset(&m_Addr, 0, sizeof(m_Addr));
-    m_Addr.sin_family = AF_INET;
-    // try xxx.xxx.xxx.xxxx first
-    m_Addr.sin_addr.s_addr = inet_addr(sz);
-    if ( m_Addr.sin_addr.s_addr == INADDR_NONE )
+    struct addrinfo hints, *res;
+    
+    ::memset(&m_Addr, 0, m_AddrLen = sizeof(struct sockaddr_in));
+    m_Addr.ss_family = AF_INET;
+    
+    ::memset(&hints, 0, sizeof(hints));
+    if ( getaddrinfo(sz, NULL, &hints, &res) == 0 )
     {
-        // otherwise try to resolve via dns
-        hostent *record = gethostbyname(sz);
-        if( record != NULL )
-        {
-            m_Addr.sin_addr.s_addr = ((in_addr * )record->h_addr)->s_addr;
-        }
+        ::memcpy(&m_Addr, res->ai_addr, m_AddrLen = res->ai_addrlen);
+        freeaddrinfo(res);
     }
 }
 
-CIp::CIp(const struct sockaddr_in *sa)
+CIp::CIp(const struct sockaddr_storage *ss, socklen_t len)
 {
-    ::memcpy(&m_Addr, sa, sizeof(m_Addr));
+    len = ( len < sizeof(m_Addr) ) ? len : sizeof(m_Addr);
+    ::memcpy(&m_Addr, ss, m_AddrLen = len);
 }
-
 
 CIp::CIp(const CIp &ip)
 {
-    ::memcpy(&m_Addr, &ip.m_Addr, sizeof(m_Addr));
+    ::memcpy(&m_Addr, &ip.m_Addr, m_AddrLen = ip.m_AddrLen);
+}
+
+CIp::CIp(const CIp &ip, uint16 port)
+{
+    ::memcpy(&m_Addr, &ip.m_Addr, m_AddrLen = ip.m_AddrLen);
+    
+    switch (m_Addr.ss_family)
+    {
+        case AF_INET:
+            ((struct sockaddr_in *)&m_Addr)->sin_port = htons(port);
+            break;
+        case AF_INET6:
+            ((struct sockaddr_in6 *)&m_Addr)->sin6_port = htons(port);
+            break;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
-// set
+// sockaddr
 
-void CIp::SetSockAddr(struct sockaddr_in *sa)
+void CIp::SetSockAddr(struct sockaddr_storage *ss, socklen_t len)
 {
-    ::memcpy(&m_Addr, sa, sizeof(m_Addr));
+    len = ( len < sizeof(m_Addr) ) ? len : sizeof(m_Addr);
+    ::memcpy(&m_Addr, ss, m_AddrLen = len);
+}
+
+struct sockaddr_storage *CIp::GetSockAddr(socklen_t &len)
+{
+    len = m_AddrLen;
+    return &m_Addr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -78,14 +98,45 @@ void CIp::SetSockAddr(struct sockaddr_in *sa)
 
 bool CIp::operator ==(const CIp &ip) const
 {
-    return ( (ip.m_Addr.sin_family == m_Addr.sin_family) &&
-             (ip.m_Addr.sin_addr.s_addr == m_Addr.sin_addr.s_addr) &&
-             (ip.m_Addr.sin_port == m_Addr.sin_port)) ;
+    if ( ip.m_Addr.ss_family != m_Addr.ss_family )
+    {
+        return false;
+    }
+    
+    switch (m_Addr.ss_family)
+    {
+        case AF_INET:
+            struct sockaddr_in *pi4, *pm4;
+            pi4 = (struct sockaddr_in *)&ip.m_Addr;
+            pm4 = (struct sockaddr_in *)&m_Addr;
+            return ( (pi4->sin_addr.s_addr == pm4->sin_addr.s_addr) &&
+                     (pi4->sin_port == pm4->sin_port) );
+        case AF_INET6:
+            struct sockaddr_in6 *pi6, *pm6;
+            pi6 = (struct sockaddr_in6 *)&ip.m_Addr;
+            pm6 = (struct sockaddr_in6 *)&m_Addr;
+            return ( IN6_ARE_ADDR_EQUAL(&pi6->sin6_addr, &pm6->sin6_addr) &&
+                     (pi6->sin6_port == pm6->sin6_port) );
+        default:
+            return false;
+    }
 }
 
 CIp::operator const char *() const
 {
-    return ::inet_ntoa(m_Addr.sin_addr);
+    switch (m_Addr.ss_family)
+    {
+        case AF_INET:
+            return ::inet_ntop(m_Addr.ss_family,
+                               &((struct sockaddr_in *)&m_Addr)->sin_addr.s_addr,
+                               m_AddrStr, sizeof(m_AddrStr));
+        case AF_INET6:
+            return ::inet_ntop(m_Addr.ss_family,
+                               ((struct sockaddr_in6 *)&m_Addr)->sin6_addr.s6_addr,
+                               m_AddrStr, sizeof(m_AddrStr));
+        default:
+            return ::strncpy(m_AddrStr, "unknown", sizeof(m_AddrStr));
+    }
 }
 
 

--- a/src/cip.cpp
+++ b/src/cip.cpp
@@ -94,6 +94,49 @@ struct sockaddr_storage *CIp::GetSockAddr(socklen_t &len)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
+// get and set
+
+uint32 CIp::GetAddr(void) const
+{
+    switch (m_Addr.ss_family)
+    {
+        case AF_INET:
+            return ((struct sockaddr_in *)&m_Addr)->sin_addr.s_addr;
+        default:
+            return 0; /* not supported */
+    }
+}
+
+uint16 CIp::GetPort(void) const
+{
+    switch (m_Addr.ss_family)
+    {
+        case AF_INET:
+            return ((struct sockaddr_in *)&m_Addr)->sin_port;
+        case AF_INET6:
+            return ((struct sockaddr_in6 *)&m_Addr)->sin6_port;
+        default:
+            return 0; /* not supported */
+    }
+}
+
+void CIp::SetPort(uint16 port)
+{
+    switch (m_Addr.ss_family)
+    {
+        case AF_INET:
+            ((struct sockaddr_in *)&m_Addr)->sin_port = port;
+            break;
+        case AF_INET6:
+            ((struct sockaddr_in6 *)&m_Addr)->sin6_port = port;
+            break;
+        default:
+            /* not supported, do nothing */
+            break;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
 // operator
 
 bool CIp::operator ==(const CIp &ip) const

--- a/src/cip.h
+++ b/src/cip.h
@@ -33,25 +33,26 @@ class CIp
 {
 public:
     // constructors
-    CIp();
+    CIp(const int af = AF_INET);
     //CIp(uint8, uint8, uint8, uint8);
-    CIp(const struct sockaddr_in *);
+    CIp(const struct sockaddr_storage *, socklen_t);
     CIp(const char *);
     CIp(const CIp &);
+    CIp(const CIp &, uint16);
     
     // destructor
     virtual ~CIp() {};
     
     // sockaddr
-    void SetSockAddr(struct sockaddr_in *);
-    struct sockaddr_in *GetSockAddr(void)     { return &m_Addr; }
+    void SetSockAddr(struct sockaddr_storage *, socklen_t);
+    struct sockaddr_storage *GetSockAddr(socklen_t &);
     
     // get
-    uint32 GetAddr(void) const                { return m_Addr.sin_addr.s_addr; }
-    uint16 GetPort(void) const                { return m_Addr.sin_port; }
+    uint32 GetAddr(void) const;
+    uint16 GetPort(void) const;
     
     // set
-    void SetPort(uint16 port)                 { m_Addr.sin_port = port; }
+    void SetPort(uint16 port);
     
     // operator
     bool operator ==(const CIp &) const;

--- a/src/cip.h
+++ b/src/cip.h
@@ -59,7 +59,9 @@ public:
     
 protected:
     // data
-    struct sockaddr_in  m_Addr;
+    struct sockaddr_storage m_Addr;
+    socklen_t m_AddrLen;
+    mutable char m_AddrStr[INET6_ADDRSTRLEN];
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/crawsocket.cpp
+++ b/src/crawsocket.cpp
@@ -113,7 +113,7 @@ int CRawSocket::Receive(CBuffer *Buffer, CIp *Ip, int timeout)
             Buffer->resize(iRecvLen);
 
             // get IP
-            Ip->SetSockAddr(&Sin);
+            Ip->SetSockAddr((struct sockaddr_storage *)&Sin, sizeof(Sin));
         }
     }
 
@@ -148,7 +148,7 @@ int CRawSocket::IcmpReceive(CBuffer *Buffer, CIp *Ip, int timeout)
             Sin.sin_family = AF_INET;
             Sin.sin_addr.s_addr = remote_iph->ip_dst.s_addr;
 
-            Ip->SetSockAddr(&Sin);
+            Ip->SetSockAddr((struct sockaddr_storage *)&Sin, sizeof(Sin));
 
         }
     }

--- a/src/creflector.cpp
+++ b/src/creflector.cpp
@@ -31,6 +31,11 @@
 #include "ctranscoder.h"
 #include "cysfnodedirfile.h"
 #include "cysfnodedirhttp.h"
+#if defined(AF_PACKET)
+#include <netpacket/packet.h>
+#elif defined(AF_LINK)
+#include <net/if_dl.h>
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // constructor
@@ -774,148 +779,53 @@ void CReflector::SendJsonOffairObject(CUdpSocket &Socket, CIp &Ip, const CCallsi
 ////////////////////////////////////////////////////////////////////////////////////////
 // MAC address helpers
 
-#ifdef __linux__
-#include <netpacket/packet.h>
-bool CReflector::UpdateListenMac(void)
+bool CReflector::UpdateListenMac(int i)
 {
-    struct ifaddrs *ifap, *ifaptr;
-    char host[NI_MAXHOST];
+    struct ifaddrs *ifa_top, *ifa;
     char *ifname = NULL;
     bool found = false;
+    socklen_t ss_len;
     
-    // iterate through all our AF_INET interface to find the one
-    // of our listening ip
-    if ( getifaddrs(&ifap) == 0 )
+    if ( getifaddrs(&ifa_top) < 0 )
+        return false;
+    
+    m_Ip[i].GetSockAddr(ss_len);
+    
+    // get interface name associated with IP address
+    for ( ifa = ifa_top; ifa != NULL; ifa = ifa->ifa_next )
     {
-        for ( ifaptr = ifap; (ifaptr != NULL) && !found; ifaptr = (ifaptr)->ifa_next )
-        {
-            // is it an AF_INET?
-            if ( ifaptr->ifa_addr->sa_family == AF_INET )
-            {
-                if (ifaptr->ifa_addr == NULL)
-                    continue;
-                
-                // get the IP
-                if ( getnameinfo(ifaptr->ifa_addr,
-                        sizeof(struct sockaddr_in),
-                        host, NI_MAXHOST,
-                        NULL, 0, NI_NUMERICHOST) == 0 )
-                {
-                    if ( CIp(host) == m_Ip )
-                    {
-                        // yes, found it
-                        found = true;
-                        ifname = new char[strlen(ifaptr->ifa_name)+1];
-                        strcpy(ifname, ifaptr->ifa_name);
-                    }
-                }
-            }
-           
+        if ( CIp((struct sockaddr_storage *)ifa->ifa_addr, ss_len) == m_Ip[i] ) {
+            found = true;
+            ifname = new char[strlen(ifa->ifa_name) + 1];
+            strcpy(ifname, ifa->ifa_name);
+            break;
         }
-        freeifaddrs(ifap);
     }
     
-    // if listening interface name found, iterate again
-    // to find the corresponding AF_PACKET interface
-    if ( found )
-    {
+    // get MAC address from interface name
+    if ( found ) {
+        void *p = NULL;
         found = false;
-        if ( getifaddrs(&ifap) == 0 )
+        for ( ifa = ifa_top; ifa != NULL; ifa = ifa->ifa_next )
         {
-            for ( ifaptr = ifap; (ifaptr != NULL) && !found; ifaptr = (ifaptr)->ifa_next )
-            {
-                if ( !strcmp((ifaptr)->ifa_name, ifname) && (ifaptr->ifa_addr->sa_family == AF_PACKET) )
-                {
-                    found = true;
-                    struct sockaddr_ll *s = (struct sockaddr_ll *)(ifaptr->ifa_addr);
-                    for ( int i = 0; i < 6; i++ )
-                    {
-                        m_Mac[i] = s->sll_addr[i];
-                    }
-                }
-            }
-        }
-        freeifaddrs(ifap);
-    }
-    
-    // done
-    return found;
-}
-#endif
-
-#if defined(__APPLE__)  && defined(__MACH__)
-#include <net/if_dl.h>
-bool CReflector::UpdateListenMac(void)
-{
-    struct ifaddrs *ifaddr;
-    int  s;
-    char host[NI_MAXHOST];
-    char *ifname = NULL;
-    bool found = false;
-    bool ok = false;
-
-    if ( getifaddrs(&ifaddr) != -1)
-    {
-        // Walk through linked list, maintaining head pointer so we can free list later.
-        // until finding our listening AF_INET interface
-        for (struct ifaddrs *ifa = ifaddr; (ifa != NULL) && !found; ifa = ifa->ifa_next)
-        {
-            if (ifa->ifa_addr == NULL)
+            if ( strcmp(ifa->ifa_name, ifname ) )
                 continue;
-
-            // is it an AF_INET?
-            if (ifa->ifa_addr->sa_family == AF_INET)
+#if defined(AF_PACKET)
+            found = ( ifa->ifa_addr->sa_family == AF_PACKET );
+            p = ifa->ifa_addr;
+#elif defined(AF_LINK)
+            found = ( ifa->ifa_addr->sa_family == AF_LINK );
+            p = LLADDR((struct sockaddr_dl *)ifa->ifa_addr);
+#endif
+            if ( found )
             {
-                // get IP
-                s = getnameinfo(ifa->ifa_addr,
-                        sizeof(struct sockaddr_in),
-                        host, NI_MAXHOST,
-                        NULL, 0, NI_NUMERICHOST);
-                if (s != 0)
-                {
-                   return false;
-                }
-                // is it our listening ip ?
-                if ( CIp(host) == m_Ip )
-                {
-                    // yes, found it
-                    found = true;
-                    ifname = new char[strlen(ifa->ifa_name)+1];
-                    strcpy(ifname, ifa->ifa_name);
-                }
+                memcpy(m_Mac[i], p, 6);
+                break;
             }
         }
-        freeifaddrs(ifaddr);
-
-        // found our interface ?
-        if ( found )
-        {
-            // yes
-            //std::cout << ifname << " : " << host << std::endl;
-            
-            // Walk again through linked list
-            // until finding our listening AF_LINK interface
-            if ( getifaddrs(&ifaddr) != -1 )
-            {
-                found = false;
-                for (struct ifaddrs *ifa = ifaddr; (ifa != NULL) && !found; ifa = ifa->ifa_next)
-                {
-                    if (ifa->ifa_addr == NULL)
-                        continue;
-                    
-                    if ( !strcmp(ifa->ifa_name, ifname) && (ifa->ifa_addr->sa_family == AF_LINK))
-                    {
-                        ::memcpy((void *)m_Mac, (void *)LLADDR((struct sockaddr_dl *)(ifa)->ifa_addr), sizeof(m_Mac));
-                        ok = true;
-                        found = true;
-                    }
-                }
-                freeifaddrs(ifaddr);
-            }
-        }
-
         delete [] ifname;
     }
-    return ok;
+    
+    freeifaddrs(ifa_top);
+    return found;
 }
-#endif

--- a/src/creflector.h
+++ b/src/creflector.h
@@ -58,9 +58,9 @@ public:
     // settings
     void SetCallsign(const CCallsign &callsign)     { m_Callsign = callsign; }
     const CCallsign &GetCallsign(void) const        { return m_Callsign; }
-    void SetListenIp(const CIp &ip)                 { m_Ip = ip; UpdateListenMac(); }
+    void SetListenIp(int i, const CIp &ip)          { m_Ip[i] = ip; UpdateListenMac(); }
     void SetTranscoderIp(const CIp &ip)             { m_AmbedIp = ip; }
-    const CIp &GetListenIp(void) const              { return m_Ip; }
+    const CIp &GetListenIp(int i = 0) const         { return m_Ip[i]; }
     const uint8 *GetListenMac(void) const           { return (const uint8 *)m_Mac; }
     const CIp &GetTranscoderIp(void) const          { return m_AmbedIp; }
     
@@ -124,7 +124,7 @@ protected:
 protected:
     // identity
     CCallsign       m_Callsign;
-    CIp             m_Ip;
+    CIp             m_Ip[UDP_SOCKET_MAX];
     uint8           m_Mac[6];
     CIp             m_AmbedIp;
     

--- a/src/creflector.h
+++ b/src/creflector.h
@@ -31,6 +31,7 @@
 #include "cprotocols.h"
 #include "cpacketstream.h"
 #include "cnotificationqueue.h"
+#include "cudpsocket.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/creflector.h
+++ b/src/creflector.h
@@ -58,10 +58,10 @@ public:
     // settings
     void SetCallsign(const CCallsign &callsign)     { m_Callsign = callsign; }
     const CCallsign &GetCallsign(void) const        { return m_Callsign; }
-    void SetListenIp(int i, const CIp &ip)          { m_Ip[i] = ip; UpdateListenMac(); }
+    void SetListenIp(int i, const CIp &ip)          { m_Ip[i] = ip; UpdateListenMac(i); }
     void SetTranscoderIp(const CIp &ip)             { m_AmbedIp = ip; }
     const CIp &GetListenIp(int i = 0) const         { return m_Ip[i]; }
-    const uint8 *GetListenMac(void) const           { return (const uint8 *)m_Mac; }
+    const uint8 *GetListenMac(int i = 0) const      { return (const uint8 *)m_Mac[i]; }
     const CIp &GetTranscoderIp(void) const          { return m_AmbedIp; }
     
     // operation
@@ -119,13 +119,13 @@ protected:
     void SendJsonOffairObject(CUdpSocket &, CIp &, const CCallsign &);
     
     // MAC address helpers
-    bool UpdateListenMac(void);
+    bool UpdateListenMac(int i);
     
 protected:
     // identity
     CCallsign       m_Callsign;
     CIp             m_Ip[UDP_SOCKET_MAX];
-    uint8           m_Mac[6];
+    uint8           m_Mac[UDP_SOCKET_MAX][6];
     CIp             m_AmbedIp;
     
     // objects

--- a/src/cudpmsgsocket.cpp
+++ b/src/cudpmsgsocket.cpp
@@ -26,17 +26,42 @@
 #include <string.h>
 #include "cudpmsgsocket.h"
 
+// neither multiple socket nor IPv6 supported
+#define MsgSocket m_Socket[0]
+#define MsgIp     m_Ip[0]
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // open
 bool CUdpMsgSocket::Open(uint16 uiPort)
 {
-    bool ret;
-    int on = 1;
-
-    ret = CUdpSocket::Open(uiPort);
-    setsockopt(m_Socket, IPPROTO_IP, IP_PKTINFO, (char *)&on, sizeof(on));
-
-    return ret;
+    int on = 1, err = -1;
+    struct sockaddr_storage *ss;
+    socklen_t ss_len;
+    
+    if ( !CUdpSocket::Open(uiPort, AF_INET) )
+    {
+        return false;
+    }
+    
+    ss = MsgIp.GetSockAddr(ss_len);
+    if ( ss->ss_family == AF_INET )
+    {
+#if defined(IP_PKTINFO)
+        err = setsockopt(MsgSocket, IPPROTO_IP, IP_PKTINFO, (char *)&on, sizeof(on));
+#elif defined(IP_RECVDSTADDR)
+        err = setsockopt(MsgSocket, IPPROTO_IP, IP_RECVDSTADDR, (char *)&on, sizeof(on));
+#endif
+    }
+    
+    if ( err < 0 )
+    {
+        CUdpSocket::Close();
+        return false;
+    }
+    else
+    {
+        return true;
+    }
 }
 
 
@@ -56,11 +81,15 @@ int CUdpMsgSocket::Receive(CBuffer *Buffer, CIp *Ip, int timeout)
 
     union {
          struct cmsghdr cm;
+#if defined(IP_PKTINFO)
          unsigned char pktinfo_sizer[sizeof(struct cmsghdr) + sizeof(struct in_pktinfo)];
+#elif defined(IP_RECVDSTADDR)
+         unsigned char pktinfo_sizer[sizeof(struct cmsghdr) + sizeof(struct sockaddr_in)];
+#endif
     } Control;
 
     // socket valid ?
-    if ( m_Socket != -1 )
+    if ( MsgSocket != -1 )
     {
         // allocate buffer
         Buffer->resize(UDP_MSG_BUFFER_LENMAX);
@@ -80,13 +109,13 @@ int CUdpMsgSocket::Receive(CBuffer *Buffer, CIp *Ip, int timeout)
 
         // control socket
         FD_ZERO(&FdSet);
-        FD_SET(m_Socket, &FdSet);
+        FD_SET(MsgSocket, &FdSet);
         tv.tv_sec = timeout / 1000;
         tv.tv_usec = (timeout % 1000) * 1000;
-        select(m_Socket + 1, &FdSet, 0, 0, &tv);
+        select(MsgSocket + 1, &FdSet, 0, 0, &tv);
         
         // read
-        iRecvLen = (int)recvmsg(m_Socket, &Msg, 0);
+        iRecvLen = (int)recvmsg(MsgSocket, &Msg, 0);
         
         // handle
         if ( iRecvLen != -1 )
@@ -95,17 +124,25 @@ int CUdpMsgSocket::Receive(CBuffer *Buffer, CIp *Ip, int timeout)
             Buffer->resize(iRecvLen);
             
             // get IP
-            Ip->SetSockAddr(&Sin);
+            Ip->SetSockAddr((struct sockaddr_storage *)&Sin, sizeof(Sin));
 
             // get local IP
             struct cmsghdr *Cmsg;
             for (Cmsg = CMSG_FIRSTHDR(&Msg); Cmsg != NULL; Cmsg = CMSG_NXTHDR(&Msg, Cmsg))
             {
+#if defined(IP_PKTINFO)
                 if (Cmsg->cmsg_level == IPPROTO_IP && Cmsg->cmsg_type == IP_PKTINFO)
                 {
                     struct in_pktinfo *PktInfo = (struct in_pktinfo *)CMSG_DATA(Cmsg);
                     m_LocalAddr.s_addr = PktInfo->ipi_spec_dst.s_addr;
                 }
+#elif defined(IP_RECVDSTADDR)
+                if (Cmsg->cmsg_level == IPPROTO_IP && Cmsg->cmsg_type == IP_RECVDSTADDR)
+                {
+                    struct sockaddr_in *DestAddr = (struct sockaddr_in *)CMSG_DATA(Cmsg);
+                    m_LocalAddr.s_addr = DestAddr->sin_addr.s_addr;
+                }
+#endif
             }
         }
     }

--- a/src/cudpsocket.cpp
+++ b/src/cudpsocket.cpp
@@ -33,7 +33,10 @@
 
 CUdpSocket::CUdpSocket()
 {
-    m_Socket = -1;
+    for ( int i = 0; i < UDP_SOCKET_MAX; i++ )
+    {
+        m_Socket[i] = -1;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -41,38 +44,43 @@ CUdpSocket::CUdpSocket()
 
 CUdpSocket::~CUdpSocket()
 {
-    if ( m_Socket != -1 )
-    {
-        Close();
-    }
+    Close();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // open & close
 
-bool CUdpSocket::Open(uint16 uiPort)
+bool CUdpSocket::Open(uint16 uiPort, int af)
 {
     bool open = false;
+    struct sockaddr_storage *ss;
+    socklen_t ss_len;
     
-    // create socket
-    m_Socket = socket(PF_INET,SOCK_DGRAM,0);
-    if ( m_Socket != -1 )
+    for ( int i = 0; i < UDP_SOCKET_MAX; i++ )
     {
-        // initialize sockaddr struct
-        ::memset(&m_SocketAddr, 0, sizeof(struct sockaddr_in));
-        m_SocketAddr.sin_family = AF_INET;
-        m_SocketAddr.sin_port = htons(uiPort);
-        m_SocketAddr.sin_addr.s_addr = inet_addr(g_Reflector.GetListenIp());
+        m_Ip[i] = CIp(AF_UNSPEC);
+        m_Socket[i] = -1;
         
-        if ( bind(m_Socket, (struct sockaddr *)&m_SocketAddr, sizeof(struct sockaddr_in)) == 0 )
+        if ( g_Reflector.GetListenIp(i) != CIp(AF_UNSPEC) )
         {
-            fcntl(m_Socket, F_SETFL, O_NONBLOCK);
-            open = true;
+            m_Ip[i] = CIp(g_Reflector.GetListenIp(i), uiPort);
+            ss = m_Ip[i].GetSockAddr(ss_len);
+            m_Socket[i] = ( af != AF_UNSPEC && af != ss->ss_family ) ?
+                -1 : socket(ss->ss_family, SOCK_DGRAM, 0);
         }
-        else
+        
+        if ( m_Socket[i] != -1 )
         {
-            close(m_Socket);
-            m_Socket = -1;
+            if ( bind(m_Socket[i], (struct sockaddr *)ss, ss_len) == 0 )
+            {
+                fcntl(m_Socket[i], F_SETFL, O_NONBLOCK);
+                open |= true;
+            }
+            else
+            {
+                close(m_Socket[i]);
+                m_Socket[i] = -1;
+            }
         }
     }
     
@@ -82,11 +90,34 @@ bool CUdpSocket::Open(uint16 uiPort)
 
 void CUdpSocket::Close(void)
 {
-    if ( m_Socket != -1 )
+    for ( int i = 0; i < UDP_SOCKET_MAX; i++ )
     {
-        close(m_Socket);
-        m_Socket = -1;
+        if ( m_Socket[i] != -1 )
+        {
+            close(m_Socket[i]);
+            m_Socket[i] = -1;
+        }
     }
+}
+
+int CUdpSocket::GetSocket(const CIp &Ip)
+{
+    CIp temp(Ip);
+    socklen_t ss_len;
+    struct sockaddr_storage *ss = temp.GetSockAddr(ss_len);
+    sa_family_t ss_family = ss->ss_family;
+    
+    for ( int i = 0; i < UDP_SOCKET_MAX; i++ )
+    {
+        ss = m_Ip[i].GetSockAddr(ss_len);
+        if ( ss_family == ss->ss_family )
+        {
+            // if ss->ss_family == AF_UNSPEC, m_Socket[i] = -1
+            return m_Socket[i];
+        }
+    }
+    
+    return -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -94,38 +125,55 @@ void CUdpSocket::Close(void)
 
 int CUdpSocket::Receive(CBuffer *Buffer, CIp *Ip, int timeout)
 {
-    struct sockaddr_in Sin;
-    fd_set FdSet;
-    unsigned int uiFromLen = sizeof(struct sockaddr_in);
-    int iRecvLen = -1;
-    struct timeval tv;
+    struct sockaddr_storage Sin;
+    struct pollfd pfd[UDP_SOCKET_MAX];
+    socklen_t uiFromLen = sizeof(Sin);
+    int i, socks, index, iRecvLen = -1;
     
     // socket valid ?
-    if ( m_Socket != -1 )
+    for ( i = socks = 0; i < UDP_SOCKET_MAX; i++ )
+    {
+        if ( m_Socket[i] != -1 )
+        {
+            pfd[socks].fd = m_Socket[i];
+            pfd[socks].events = POLLIN;
+            socks++;
+        }
+    }
+    
+    if ( socks != 0 )
     {
         // control socket
-        FD_ZERO(&FdSet);
-        FD_SET(m_Socket, &FdSet);
-        tv.tv_sec = timeout / 1000;
-        tv.tv_usec = (timeout % 1000) * 1000;
-        select(m_Socket + 1, &FdSet, 0, 0, &tv);
+        poll(pfd, socks, timeout);
         
-        // allocate buffer
-        Buffer->resize(UDP_BUFFER_LENMAX);
-        
-        // read
-        iRecvLen = (int)recvfrom(m_Socket,
-            (void *)Buffer->data(), UDP_BUFFER_LENMAX,
-            0, (struct sockaddr *)&Sin, &uiFromLen);
-        
-        // handle
-        if ( iRecvLen != -1 )
+        for ( i = 0; i < socks; i++ )
         {
-            // adjust buffer size
-            Buffer->resize(iRecvLen);
+            // round robin
+            index = (i + m_Counter) % socks;
             
-            // get IP
-            Ip->SetSockAddr(&Sin);
+            if ( pfd[index].revents & POLLIN )
+            {
+                // allocate buffer
+                Buffer->resize(UDP_BUFFER_LENMAX);
+                
+                // read
+                iRecvLen = (int)recvfrom(pfd[index].fd,
+                    (void *)Buffer->data(), UDP_BUFFER_LENMAX,
+                    0, (struct sockaddr *)&Sin, &uiFromLen);
+                
+                // handle
+                if ( iRecvLen != -1 )
+                {
+                    // adjust buffer size
+                    Buffer->resize(iRecvLen);
+                    
+                    // get IP
+                    Ip->SetSockAddr(&Sin, uiFromLen);
+                    
+                    m_Counter++;
+                    break;
+                }
+            }
         }
     }
  
@@ -139,35 +187,41 @@ int CUdpSocket::Receive(CBuffer *Buffer, CIp *Ip, int timeout)
 int CUdpSocket::Send(const CBuffer &Buffer, const CIp &Ip)
 {
     CIp temp(Ip);
-    return (int)::sendto(m_Socket,
+    socklen_t ss_len;
+    struct sockaddr_storage *ss = temp.GetSockAddr(ss_len);
+    return (int)::sendto(GetSocket(Ip),
            (void *)Buffer.data(), Buffer.size(),
-           0, (struct sockaddr *)temp.GetSockAddr(), sizeof(struct sockaddr_in));
+           0, (struct sockaddr *)ss, ss_len);
 }
 
 int CUdpSocket::Send(const char *Buffer, const CIp &Ip)
 {
     CIp temp(Ip);
-    return (int)::sendto(m_Socket,
+    socklen_t ss_len;
+    struct sockaddr_storage *ss = temp.GetSockAddr(ss_len);
+    return (int)::sendto(GetSocket(Ip),
            (void *)Buffer, ::strlen(Buffer),
-           0, (struct sockaddr *)temp.GetSockAddr(), sizeof(struct sockaddr_in));
+           0, (struct sockaddr *)ss, ss_len);
 }
 
 int CUdpSocket::Send(const CBuffer &Buffer, const CIp &Ip, uint16 destport)
 {
-    CIp temp(Ip);
-    temp.GetSockAddr()->sin_port = htons(destport);
-    return (int)::sendto(m_Socket,
+    CIp temp(Ip, destport);
+    socklen_t ss_len;
+    struct sockaddr_storage *ss = temp.GetSockAddr(ss_len);
+    return (int)::sendto(GetSocket(Ip),
                          (void *)Buffer.data(), Buffer.size(),
-                         0, (struct sockaddr *)temp.GetSockAddr(), sizeof(struct sockaddr_in));
+                         0, (struct sockaddr *)ss, ss_len);
 }
 
 int CUdpSocket::Send(const char *Buffer, const CIp &Ip, uint16 destport)
 {
-    CIp temp(Ip);
-    temp.GetSockAddr()->sin_port = htons(destport);
-    return (int)::sendto(m_Socket,
+    CIp temp(Ip, destport);
+    socklen_t ss_len;
+    struct sockaddr_storage *ss = temp.GetSockAddr(ss_len);
+    return (int)::sendto(GetSocket(Ip),
                          (void *)Buffer, ::strlen(Buffer),
-                         0, (struct sockaddr *)temp.GetSockAddr(), sizeof(struct sockaddr_in));
+                         0, (struct sockaddr *)ss, ss_len);
 }
 
 

--- a/src/cudpsocket.h
+++ b/src/cudpsocket.h
@@ -29,6 +29,7 @@
 //#include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <arpa/inet.h>
@@ -40,6 +41,7 @@
 // define
 
 #define UDP_BUFFER_LENMAX       1024
+#define UDP_SOCKET_MAX          2
 
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -55,9 +57,9 @@ public:
     ~CUdpSocket();
     
     // open & close
-    bool Open(uint16);
+    bool Open(uint16, int = AF_UNSPEC);
     void Close(void);
-    int  GetSocket(void)        { return m_Socket; }
+    int  GetSocket(const CIp &);
     
     // read
     int Receive(CBuffer *, CIp *, int);
@@ -70,8 +72,9 @@ public:
     
 protected:
     // data
-    int                 m_Socket;
-    struct sockaddr_in  m_SocketAddr;
+    int                 m_Socket[UDP_SOCKET_MAX];
+    CIp                 m_Ip[UDP_SOCKET_MAX];
+    unsigned int        m_Counter;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cysfprotocol.cpp
+++ b/src/cysfprotocol.cpp
@@ -67,6 +67,11 @@ bool CYsfProtocol::Init(void)
     // update time
     m_LastKeepaliveTime.Now();
     
+    // random number generator
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    m_Random = mt;
+    
     // done
     return ok;
 }
@@ -459,7 +464,7 @@ bool CYsfProtocol::IsValidDvHeaderPacket(const CIp &Ip, const CYSFFICH &Fich, co
     if ( Fich.getFI() == YSF_FI_HEADER )
     {
         // get stream id
-        uint32 uiStreamId = IpToStreamId(Ip);
+        uint32 uiStreamId = CreateStreamId();
         
         // get header data
         CYSFPayload ysfPayload;
@@ -538,7 +543,7 @@ bool CYsfProtocol::IsValidDvFramePacket(const CIp &Ip, const CYSFFICH &Fich, con
     if ( Fich.getFI() == YSF_FI_COMMUNICATIONS )
     {
         // get stream id
-        uint32 uiStreamId = IpToStreamId(Ip);
+        uint32 uiStreamId = CreateStreamId();
         
         // get DV frames
         uint8   ambe0[AMBEPLUS_SIZE];
@@ -595,7 +600,7 @@ bool CYsfProtocol::IsValidDvLastFramePacket(const CIp &Ip, const CYSFFICH &Fich,
     if ( Fich.getFI() == YSF_FI_TERMINATOR )
     {
         // get stream id
-        uint32 uiStreamId = IpToStreamId(Ip);
+        uint32 uiStreamId = CreateStreamId();
         
         // get DV frames
         {
@@ -1016,9 +1021,9 @@ uint32 CYsfProtocol::CalcHash(const uint8 *buffer, int len) const
 
 
 // uiStreamId helpers
-uint32 CYsfProtocol::IpToStreamId(const CIp &ip) const
+uint32 CYsfProtocol::CreateStreamId(void) const
 {
-    return ip.GetAddr() ^ (uint32)(MAKEDWORD(ip.GetPort(), ip.GetPort()));
+    return m_Random();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cysfprotocol.h
+++ b/src/cysfprotocol.h
@@ -120,7 +120,7 @@ protected:
     bool EncodeServerStatusPacket(CBuffer *) const;
     
     // uiStreamId helpers
-    uint32 IpToStreamId(const CIp &) const;
+    uint32 CreateStreamId(void) const;
     
     // debug
     bool DebugTestDecodePacket(const CBuffer &);
@@ -134,6 +134,9 @@ protected:
     
     // for queue header caches
     std::array<CYsfStreamCacheItem, NB_OF_MODULES>    m_StreamsCache;
+    
+    // random number generator
+    mutable std::mt19937 m_Random;
     
     // for wires-x
     CWiresxCmdHandler   m_WiresxCmdHandler;

--- a/src/main.h
+++ b/src/main.h
@@ -39,8 +39,11 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <random>
 #include <algorithm>
 #include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <ifaddrs.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main.h
+++ b/src/main.h
@@ -62,6 +62,7 @@
 //#define DEBUG_NO_ERROR_ON_XML_OPEN_FAIL
 //#define DEBUG_DUMPFILE
 //#define DEBUG_NO_G3_ICMP_SOCKET
+//#define DEBUG_NO_G3_SUPPORT
 
 // reflector ---------------------------------------------------
 

--- a/src/makefile
+++ b/src/makefile
@@ -1,4 +1,4 @@
-CC=g++
+CC=c++
 CFLAGS=-c -std=c++11 -pthread
 LDFLAGS=-std=c++11 -pthread
 SOURCES=$(wildcard *.cpp)


### PR DESCRIPTION
This is reconstruction of PR #122, #162 and #189.

cimrsprotocol.cpp needs to be changed, but not yet.
reason: Is there any reason to use MAC address? What is this address works in Yaesu IMRS protocol?? Simply using 48bit number is not enough???

issue #204: SetPort()/GetPort() does not use htons()/ntohs() is not fixed yet.

original xlxd-2.5.x (no IPv6 edition)'s CReflector::UpdateListenMac() for linux looks delete[] ifname forgotten. I rewrite this to more portable and simple.
 
