### PR TITLE
fix Linux AF_INET iteration segfault

### DIFF
--- a/src/creflector.cpp
+++ b/src/creflector.cpp
@@ -790,7 +790,7 @@ bool CReflector::UpdateListenMac(void)
         for ( ifaptr = ifap; (ifaptr != NULL) && !found; ifaptr = (ifaptr)->ifa_next )
         {
             // is it an AF_INET?
-            if ( ifaptr->ifa_addr->sa_family == AF_INET )
+            if ( ifaptr->ifa_addr && ifaptr->ifa_addr->sa_family == AF_INET )
             {
                 if (ifaptr->ifa_addr == NULL)
                     continue;


### PR DESCRIPTION
Prevent segfault when WireGuard is active and an interface has `ifaptr->ifa_addr == NULL`