### PR TITLE
change SetYsfCallsign() to trim callsign on null char

### DIFF
--- a/src/ccallsign.cpp
+++ b/src/ccallsign.cpp
@@ -207,7 +207,7 @@ void CCallsign::SetYsfCallsign(const char *sz)
     m_uiDmrid = 0;
 
     // set callsign
-    for ( i = 0; (i < sizeof(m_Callsign)) && (sz[i] != '/') && (sz[i] != '-'); i++ )
+    for ( i = 0; (i < sizeof(m_Callsign)) && (sz[i] != '/') && (sz[i] != '-') && (sz[i] != 0x00); i++ )
     {
         m_Callsign[i] = sz[i];
     }

--- a/src/main.h
+++ b/src/main.h
@@ -50,7 +50,7 @@
 
 #define VERSION_MAJOR                   2
 #define VERSION_MINOR                   5
-#define VERSION_REVISION                1
+#define VERSION_REVISION                2
 
 // global ------------------------------------------------------
 


### PR DESCRIPTION
Small patch to change SetYsfCallsign() to trim/stop parsing callsign when it finds null char, this was actually done before v2.5.x as callsign was copied until strlen() on constructor function. This workarounds DVSwitch YSF users being unable to TX on v2.5.x as described on this topic: https://xlxbbs.epf.lu/viewtopic.php?p=2227#p2227