### PR TITLE
fix frame sequence for streams initiated on different mode

### DIFF
--- a/src/cpacket.cpp
+++ b/src/cpacket.cpp
@@ -174,7 +174,10 @@ void CPacket::UpdatePids(uint32 pid)
     }
     if ( m_uiYsfPacketFrameId == 0xFF )
     {
-        m_uiYsfPacketFrameId = ((pid / 5) & 0x7FU) << 1;
+        if (IsDvHeader())
+            m_uiYsfPacketFrameId = 0;
+        else
+            m_uiYsfPacketFrameId = (((pid / 5) + 1) & 0x7FU) << 1;
     }
     // imrs pid needs update ?
     if ( m_uiImrsPacketId == 0xFF )
@@ -184,6 +187,9 @@ void CPacket::UpdatePids(uint32 pid)
     }
     if ( m_uiImrsPacketFrameId == 0xFFFF )
     {
-        m_uiImrsPacketFrameId = LOWORD(pid / 5);
+        if (IsDvHeader())
+            m_uiImrsPacketFrameId = 0;
+        else
+            m_uiImrsPacketFrameId = LOWORD((pid / 5) + 1);
     }
 }

--- a/src/cpacketstream.cpp
+++ b/src/cpacketstream.cpp
@@ -77,7 +77,8 @@ void CPacketStream::Push(CPacket *Packet)
 {
     // update stream dependent packet data
     m_LastPacketTime.Now();
-    Packet->UpdatePids(m_uiPacketCntr++);
+    Packet->UpdatePids(m_uiPacketCntr);
+    if (Packet->IsDvFrame()) { m_uiPacketCntr++; }
     // transcoder avaliable ?
     if ( m_CodecStream != NULL )
     {


### PR DESCRIPTION
This small patch fixes frame sequence applied by UpdatePids() (i.e. for streams initiated on different mode), m_uiPacketCntr should not be incremented by dv header packet else sequence for dv frames will start at 1 instead of 0 as it should.

This caused even further issues for DMR/YSF: with m_uiDmrPacketSubid and m_uiYsfPacketSubId also being calculated from the above, actually if we have for example a stream initiated on D-Star, 1st and 2nd dv frames would be transcoded to 2nd and 3rd AMBE frames of the DMR "triplet", the 1st AMBE frame would be the one stored at m_StreamsCache from the previous stream! and... frame sequence on EncodeDvPacket() being picked from that DvFrame0 (the one from previous stream), then something random...

The wrong frame sequence caused all DMR streams (when initiated on different mode, else original sequence is preserved) to show up on MMDVMHost as having packet loss.

(m_uiYsfPacketFrameId and m_uiImrsPacketFrameId are adjusted to match the change, as these should remain 0 for header packet and 1, 2, ... for dv packets)