### PR TITLE
implement transcoder options and auto mode

### DIFF
--- a/config/xlxd.transcoder
+++ b/config/xlxd.transcoder
@@ -1,0 +1,19 @@
+#########################################################################################
+#  XLXD transcoder options file
+#
+#  One line per entry, each entry specifies a transcoder option.
+#
+#  Valid options (case-sensitive):
+#  Address <ip>          - Ip address of the ambed server used for transcoding.
+#  ModulesOn <modules>   - A string with all modules which transcoding should be enabled,
+#                          "*" means all modules.
+#  ModulesAuto <modules> - A string with all modules which transcoding should be enabled
+#                          in automatic mode (transcoding will get enabled only if there
+#                          are clients linked on the module with different codecs),
+#                          "*" means all modules. ModulesOn supersedes ModulesAuto.
+#
+#########################################################################################
+
+Address 127.0.0.1
+ModulesOn ABCD
+ModulesAuto *

--- a/dashboard/pgs/config.inc.php
+++ b/dashboard/pgs/config.inc.php
@@ -23,6 +23,7 @@ $PageOptions['PageRefreshActive']                    = true;		// Activate automa
 $PageOptions['PageRefreshDelay']                     = '10000';		// Page refresh time in miliseconds
 
 $PageOptions['NumberOfModules']                      = 10;		// Number of Modules enabled on reflector
+$PageOptions['TranscoderFile']                       = '/xlxd/xlxd.transcoder';			// Path to transcoder file
 
 $PageOptions['RepeatersPage'] = array();
 $PageOptions['RepeatersPage']['LimitTo']             = 99;		// Number of Repeaters to show

--- a/dashboard/pgs/modules.php
+++ b/dashboard/pgs/modules.php
@@ -1,8 +1,9 @@
 <table class="listingtable">
  <tr>
-   <th width="80" rowspan="2">Module</th>
+   <th width="75" rowspan="2">Module</th>
    <th width="130" rowspan="2">Name</th>
-   <th width="65" rowspan="2">Users</th>
+   <th width="60" rowspan="2">Users</th>
+   <th width="60" rowspan="2">Trans<br />coder</th>
    <th colspan="2">DPlus</th>
    <th colspan="2">DExtra</th>
    <th colspan="2">DCS</th>
@@ -11,16 +12,34 @@
  </tr>
  <tr>
    <th width="100">URCALL</th>
-   <th width="100">DTMF</th>
+   <th width="85">DTMF</th>
    <th width="100">URCALL</th>
-   <th width="100">DTMF</th>
+   <th width="85">DTMF</th>
    <th width="100">URCALL</th>
-   <th width="100">DTMF</th>
+   <th width="85">DTMF</th>
  </tr>
 <?php
 
 $ReflectorNumber = substr($Reflector->GetReflectorName(), 3, 3);
 $NumberOfModules = isset($PageOptions['NumberOfModules']) ? min(max($PageOptions['NumberOfModules'],0),26) : 26;
+
+$TranscoderModulesOn = '';
+$TranscoderModulesAuto = '';
+if (isset($PageOptions['TranscoderFile']) && file_exists($PageOptions['TranscoderFile']) && is_readable($PageOptions['TranscoderFile'])) {
+   $TranscoderFileContent = file($PageOptions['TranscoderFile']);
+   for ($i=0; $i < count($TranscoderFileContent); $i++) {
+      if (substr(trim($TranscoderFileContent[$i]), 0, 1) != '#') {
+         $TranscoderOption = explode(" ", trim($TranscoderFileContent[$i]));
+         if (isset($TranscoderOption[0]) && isset($TranscoderOption[1])) {
+            if ($TranscoderOption[0] === 'ModulesOn') {
+               $TranscoderModulesOn = trim($TranscoderOption[1]);
+            } else if ($TranscoderOption[0] === 'ModulesAuto') {
+               $TranscoderModulesAuto = trim($TranscoderOption[1]);
+            }
+         }
+      }
+   }
+}
 
 $odd = "";
 
@@ -30,11 +49,19 @@ for ($i = 1; $i <= $NumberOfModules; $i++) {
 
    if ($odd == "#FFFFFF") { $odd = "#F1FAFA"; } else { $odd = "#FFFFFF"; }
 
+   $transcoderstate = 'Off';
+   if ((strstr($TranscoderModulesOn,'*') !== false) || (strstr($TranscoderModulesOn,$module) !== false)) {
+      $transcoderstate = 'On';
+   } else if ((strstr($TranscoderModulesAuto,'*') !== false) || (strstr($TranscoderModulesAuto,$module) !== false)) {
+      $transcoderstate = 'Auto';
+   }
+
    echo '
  <tr height="30" bgcolor="'.$odd.'" onMouseOver="this.bgColor=\'#FFFFCA\';" onMouseOut="this.bgColor=\''.$odd.'\';">
    <td align="center">'. $module .'</td>
    <td align="center">'. (empty($PageOptions['ModuleNames'][$module]) ? '-' : $PageOptions['ModuleNames'][$module]) .'</td>
    <td align="center">'. count($Reflector->GetNodesInModulesByID($module)) .'</td>
+   <td align="center">'. $transcoderstate .'</td>
    <td align="center">'. 'REF' . $ReflectorNumber . $module . 'L' .'</td>
    <td align="center">'. (is_numeric($ReflectorNumber) ? '*' . sprintf('%01d',$ReflectorNumber) . (($i<=4)?$module:sprintf('%02d',$i)) : '-') .'</td>
    <td align="center">'. 'XRF' . $ReflectorNumber . $module . 'L' .'</td>

--- a/scripts/xlxd
+++ b/scripts/xlxd
@@ -19,7 +19,7 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 # change below settings according to your system
 NAME="xlxd"
 DAEMON="/xlxd/xlxd"
-ARGUMENTS="XLX999 192.168.1.240 127.0.0.1"
+ARGUMENTS="XLX999 192.168.1.240"
 PIDFILE="/var/log/xlxd.pid"
 USER=root
 GROUP=root

--- a/src/cpacketstream.cpp
+++ b/src/cpacketstream.cpp
@@ -40,7 +40,7 @@ CPacketStream::CPacketStream()
 ////////////////////////////////////////////////////////////////////////////////////////
 // open / close
 
-bool CPacketStream::Open(const CDvHeaderPacket &DvHeader, CClient *client)
+bool CPacketStream::Open(const CDvHeaderPacket &DvHeader, CClient *client, bool enableTranscoding)
 {
     bool ok = false;
     
@@ -54,7 +54,11 @@ bool CPacketStream::Open(const CDvHeaderPacket &DvHeader, CClient *client)
         m_DvHeader = DvHeader;
         m_OwnerClient = client;
         m_LastPacketTime.Now();
-        m_CodecStream = g_Transcoder.GetStream(this, client->GetCodec());
+        if (enableTranscoding) {
+            m_CodecStream = g_Transcoder.GetStream(this, client->GetCodec());
+        } else {
+            m_CodecStream = g_Transcoder.GetStream(this, CODEC_NONE);
+        }
         ok = true;
     }
     return ok;

--- a/src/cpacketstream.h
+++ b/src/cpacketstream.h
@@ -48,7 +48,7 @@ public:
     virtual ~CPacketStream() {};
 
     // open / close
-    bool Open(const CDvHeaderPacket &, CClient *);
+    bool Open(const CDvHeaderPacket &, CClient *, bool enableTranscoding);
     void Close(void);
     
     // push & pop

--- a/src/ctranscoder.h
+++ b/src/ctranscoder.h
@@ -66,6 +66,10 @@ public:
     static void Thread(CTranscoder *);
     void Task(void);
 
+    // options
+    bool IsModuleOn(char);
+    bool IsModuleAuto(char);
+
 protected:
     // keepalive helpers
     void HandleKeepalives(void);
@@ -79,6 +83,11 @@ protected:
     void EncodeKeepAlivePacket(CBuffer *);
     void EncodeOpenstreamPacket(CBuffer *, uint8, uint8);
     void EncodeClosestreamPacket(CBuffer *, uint16);
+
+    // options
+    char *TrimWhiteSpaces(char *);
+    void NeedReload(void);
+    void ReadOptions(void);
     
 protected:
     // streams
@@ -103,6 +112,12 @@ protected:
     // time
     CTimePoint      m_LastKeepaliveTime;
     CTimePoint      m_LastActivityTime;
+
+    // options
+    std::string         m_ModulesOn;
+    std::string         m_ModulesAuto;
+    CTimePoint          m_LastNeedReloadTime;
+    time_t              m_LastModTime;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,10 +87,10 @@ int main(int argc, const char * argv[])
 #endif
 
     // check arguments
-    if ( argc != 4 )
+    if ( argc != 3 )
     {
-        std::cout << "Usage: xlxd callsign xlxdip ambedip" << std::endl;
-        std::cout << "example: xlxd XLX999 192.168.178.212 127.0.0.1" << std::endl;
+        std::cout << "Usage: xlxd callsign xlxdip" << std::endl;
+        std::cout << "example: xlxd XLX999 192.168.178.212" << std::endl;
         return 1;
     }
 
@@ -100,7 +100,7 @@ int main(int argc, const char * argv[])
     // initialize reflector
     g_Reflector.SetCallsign(argv[1]);
     g_Reflector.SetListenIp(CIp(argv[2]));
-    g_Reflector.SetTranscoderIp(CIp(CIp(argv[3])));
+    g_Reflector.SetTranscoderIp(CIp("127.0.0.1")); // default if xlxd.transcoder does not exist
   
     // and let it run
     if ( !g_Reflector.Start() )

--- a/src/main.h
+++ b/src/main.h
@@ -181,6 +181,7 @@
 #define BLACKLIST_PATH                  "/xlxd/xlxd.blacklist"
 #define INTERLINKLIST_PATH              "/xlxd/xlxd.interlink"
 #define TERMINALOPTIONS_PATH            "/xlxd/xlxd.terminal"
+#define TRANSCODEROPTIONS_PATH          "/xlxd/xlxd.transcoder"
 #define DEBUGDUMP_PATH                  "/var/log/xlxd.debug"
 
 // system constants ---------------------------------------------


### PR DESCRIPTION
This patch implements transcoder options file allowing to easily define modules which transcoding should be enabled and also implements an automatic transcoding mode (in this mode transcoding will get enabled only if there are clients linked on the module with different codecs). Options on file (modules and ambed ip) can be changed and they will take immediate effect without the need to restart xlxd (the file will be monitored for changes, every 30s, and reload options if changed, like for other options files of the program), this can also be useful if ambed is on dynamic IP (an external script may be easily made to monitor IP changes and update options file). The transcoder state (off/on/auto) is also added on modules list page of the dashboard.

The automatic transcoding mode may be useful to avoid wasting transcoder channels unnecessarily if all clients on a module use the same codec, however it haves a small disadvantage, for example if on a module there are only D-Star clients linked and none in DMR/YSF then the transcoding is not active, however if suddenly someone links on DMR/YSF while someone already transmitting (on D-Star) then this 1st DMR/YSF client gets a transmission without audio, because transcoding is not active yet, only when a new transmission is started the transcoder will get active. Anyway this is a small detail and this automatic mode may still be interesting for less important modules which we may want to allow transcoding for occasional usage, without always wasting transcoder channels unnecessarily for that module.
Also note that for DPlus "listening" mode users, before they transmit then reflector doesn't know what module they are in, then these don't trigger transcoding in automatic mode (if remaining clients on the module are in DMR/YSF), however these DPlus users obviously just need to key PTT shortly to get module and trigger auto transcoding.
