### PR TITLE
Add support for staged install

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -1,33 +1,48 @@
-CC=g++
-CFLAGS=-c -std=c++11 -pthread
-LDFLAGS=-std=c++11 -pthread
+ALL_CXXFLAGS=-std=c++11 -pthread $(CXXFLAGS)
 SOURCES=$(wildcard *.cpp)
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=xlxd
 
-all: $(SOURCES) $(EXECUTABLE)
+# variables for staged installation
+# directory variables - https://www.gnu.org/software/make/manual/html_node/Directory-Variables.html
+# DESTDIR - https://www.gnu.org/software/make/manual/html_node/DESTDIR.html
+# ComamndVariables - #https://www.gnu.org/software/make/manual/html_node/Command-Variables.html
+prefix=/usr/local
+exec_prefix=$(prefix)
+# by default install under /xlxd/ - it should be $(exec_dir)/sbin
+sbin_dir=/xlxd
+# by default install config under /xlxd/ - it should be $(prefix)/etc
+sysconf_dir=/xlxd
+INSTALL=install
+INSTALL_PROGRAM=$(INSTALL)
+INSTALL_DATA=${INSTALL} -m 644
+
+all: $(OBJECTS) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+	$(CXX) $(CPPFLAGS) $(ALL_CXXFLAGS) $(OBJECTS) -o $@
 
-.cpp.o:
-	$(CC) $(CFLAGS) $< -o $@
+.cpp.o: %.h
+	$(CXX) -c $(CPPFLAGS) $(ALL_CXXFLAGS) $<
 
+.PHONY: clean
 clean:
 	$(RM) $(EXECUTABLE) *.o
 
+.PHONY: install
 install:
-	mkdir -p /xlxd
-	cp -f $(EXECUTABLE) /xlxd/
-	[ -f /xlxd/xlxd.blacklist ] && \
-		cp ../config/xlxd.blacklist /xlxd/xlxd.blacklist.sample || \
-		cp ../config/xlxd.blacklist /xlxd/xlxd.blacklist
-	[ -f /xlxd/xlxd.whitelist ] && \
-		cp ../config/xlxd.whitelist /xlxd/xlxd.whitelist.sample || \
-		cp ../config/xlxd.whitelist /xlxd/xlxd.whitelist
-	[ -f /xlxd/xlxd.interlink ] && \
-		cp ../config/xlxd.interlink /xlxd/xlxd.interlink.sample || \
-		cp ../config/xlxd.interlink /xlxd/xlxd.interlink
-	[ -f /xlxd/xlxd.terminal ] && \
-		cp ../config/xlxd.terminal /xlxd/xlxd.terminal.sample || \
-		cp ../config/xlxd.terminal /xlxd/xlxd.terminal
+	$(INSTALL) -d $(DESTDIR)$(sbin_dir)
+	$(INSTALL_PROGRAM) $(EXECUTABLE) $(DESTDIR)$(sbin_dir)/$(EXECUTABLE)
+	$(INSTALL) -d $(DESTDIR)$(sysconf_dir)
+	[ -f $(DESTDIR)$(sysconf_dir)/xlxd.blacklist ] && \
+		$(INSTALL_DATA) ../config/xlxd.blacklist  $(DESTDIR)$(sysconf_dir)/xlxd.blacklist.sample || \
+		$(INSTALL_DATA) ../config/xlxd.blacklist  $(DESTDIR)$(sysconf_dir)/xlxd.blacklist
+	[ -f $(DESTDIR)$(sysconf_dir)/xlxd.whitelist ] && \
+		$(INSTALL_DATA) ../config/xlxd.whitelist  $(DESTDIR)$(sysconf_dir)/xlxd.whitelist.sample || \
+		$(INSTALL_DATA) ../config/xlxd.whitelist  $(DESTDIR)$(sysconf_dir)/xlxd.whitelist
+	[ -f $(DESTDIR)$(sysconf_dir)/xlxd.interlink ] && \
+		$(INSTALL_DATA) ../config/xlxd.interlink  $(DESTDIR)$(sysconf_dir)/xlxd.interlink.sample || \
+		$(INSTALL_DATA) ../config/xlxd.interlink  $(DESTDIR)$(sysconf_dir)/xlxd.interlink
+	[ -f $(DESTDIR)$(sysconf_dir)/xlxd.terminal ] && \
+		$(INSTALL_DATA) ../config/xlxd.terminal  $(DESTDIR)$(sysconf_dir)/xlxd.terminal.sample || \
+		$(INSTALL_DATA) ../config/xlxd.terminal  $(DESTDIR)$(sysconf_dir)/xlxd.terminal


### PR DESCRIPTION
This is a general refactor of the makefile with the introduction of
staged install.

Is now possible to install with make install DESTDIR=build
and it will build the default xlxd install structure under the build
folder.

This if extremely usefull for building deb packages without using root
user and without interfeering with the host xlxd installation.

It also define some standard make directory variables, all defaulted
to /xlxd, to better customize the software at compile time.

make staged install:
https://www.gnu.org/prep/standards/html_node/DESTDIR.html
make directory variables:
https://www.gnu.org/software/make/manual/html_node/Directory-Variables.html

73 de IU5BON 