### PR TITLE
fix ambed openstream timeout issue

### DIFF
--- a/src/csemaphore.cpp
+++ b/src/csemaphore.cpp
@@ -32,6 +32,7 @@ CSemaphore::CSemaphore()
 {
     // Initialized as locked.
     m_Count = 0;
+    m_WaitingCount = 0;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -66,7 +67,21 @@ bool CSemaphore::WaitFor(uint ms)
     {
         m_Count--;
     }
+    if ( m_WaitingCount > 0 )
+    {
+        m_WaitingCount--;
+    }
     return ok;
-    
 }
 
+void CSemaphore::PreWaitFor(void)
+{
+    std::unique_lock<decltype(m_Mutex)> lock(m_Mutex);
+    // discard timedout notify(s) count
+    if ( m_Count > m_WaitingCount )
+    {
+        m_Count = m_WaitingCount;
+    }
+    // pre flag waiting notify
+    m_WaitingCount++;
+}

--- a/src/csemaphore.h
+++ b/src/csemaphore.h
@@ -43,12 +43,14 @@ public:
     void Notify(void);
     void Wait(void);
     bool WaitFor(uint);
+    void PreWaitFor(void);
     
 protected:
     // data
     std::mutex              m_Mutex;
     std::condition_variable m_Condition;
     size_t                  m_Count;
+    size_t                  m_WaitingCount;
 
 };
 

--- a/src/ctranscoder.cpp
+++ b/src/ctranscoder.cpp
@@ -216,6 +216,7 @@ CCodecStream *CTranscoder::GetStream(CPacketStream *PacketStream, uint8 uiCodecI
         {
             // yes, post openstream request
             EncodeOpenstreamPacket(&Buffer, uiCodecIn, (uiCodecIn == CODEC_AMBEPLUS) ? CODEC_AMBE2PLUS : CODEC_AMBEPLUS);
+            m_SemaphoreOpenStream.PreWaitFor(); // pre flag waiting notify and discard timedout notify(s) count
             m_Socket.Send(Buffer, m_Ip, TRANSCODER_PORT);
             
             // wait relpy here


### PR DESCRIPTION
This patch fixes an old bug on xlxd related with ambed openstream timeout, actually if the openstream response packet from ambed to xlxd is completely lost then no problem happens at all, however if timeout is reached but xlxd still gets the packet after timeout then transcoding gets fully broken with crashing streams forever until xlxd is restarted.

The problem is discussed at issues https://github.com/LX3JL/xlxd/issues/115 , https://github.com/LX3JL/xlxd/issues/141 and probably also https://github.com/LX3JL/xlxd/issues/168 , the workaround of @lucamarche-iz1mlt is to tweak this timeout (and inherently some other timeouts) to an high value to avoid it but the bug is still there... also it should be easy for a malicious user to take advantage of this to break any XLX, as easy as simulate an openstream response packet...

The problem happens because when xlxd gets openstream response packet it will always call m_SemaphoreOpenStream.Notify(), thus incrementing semaphore m_Count that will never be decremented because WaitFor() already timedout... and... this incremented m_Count will cause all subsequent WaitFor() calls to return immediately, before getting the required stream details... My solution is maybe not the most elegant code but it fixes the problem, I didn't use just Reset() as it could eventually discard concurrent notifies...