### PR TITLE
Added missing 0x20 in DCS EncodeDisconnectPacket

### DIFF
--- a/src/cdcsprotocol.cpp
+++ b/src/cdcsprotocol.cpp
@@ -526,6 +526,7 @@ void CDcsProtocol::EncodeDisconnectPacket(CBuffer *Buffer, CClient *Client)
     Buffer->Set((uint8 *)(const char *)Client->GetCallsign(), CALLSIGN_LEN-1);
     Buffer->Append((uint8)' ');
     Buffer->Append((uint8)Client->GetModule());
+    Buffer->Append((uint8)' ');
     Buffer->Append((uint8)0x00);
     Buffer->Append((uint8 *)(const char *)GetReflectorCallsign(), CALLSIGN_LEN-1);
     Buffer->Append((uint8)' ');


### PR DESCRIPTION
As is, EncodeDisconnectPacket will fail IsValidDisconnectPacket check. The encoded packet is only has 18 bytes instead of 19 because it's missing a 0x20.