### PR TITLE
Dinamyc configuration of firsts DG-ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 src/xlxd
 ambed/ambed
 ambedtest/ambedtest
+.DS_Store
+.vscode/

--- a/src/cimrsprotocol.cpp
+++ b/src/cimrsprotocol.cpp
@@ -908,9 +908,9 @@ char CImrsProtocol::DgidToModule(uint8 uiDgid) const
 {
     char cModule = ' ';
     
-    if ( (uiDgid >= 10) && (uiDgid < (10+NB_OF_MODULES)) )
+    if ( (uiDgid >= FIRST_DG_ID) && (uiDgid < (FIRST_DG_ID+NB_OF_MODULES)) )
     {
-        cModule = 'A' + (uiDgid-10);
+        cModule = 'A' + (uiDgid-FIRST_DG_ID);
     }
     return cModule;
     
@@ -921,7 +921,7 @@ uint8 CImrsProtocol::ModuleToDgid(char cModule) const
     
     if ( (cModule >= 'A') && (cModule < ('A'+NB_OF_MODULES)) )
     {
-        uiDgid = 10 + (cModule - 'A');
+        uiDgid = FIRST_DG_ID + (cModule - 'A');
     }
     return uiDgid;
 }

--- a/src/cimrsprotocol.cpp
+++ b/src/cimrsprotocol.cpp
@@ -659,13 +659,16 @@ void CImrsProtocol::EncodePongPacket(CBuffer *Buffer) const
     // radioid
     Buffer->Append(radioid, sizeof(radioid));
     // list of authorised dg-id
-    // enable dg-id 2 & 10 -> 10+NBmodules
+    // enable dg-id 2 & First DG-ID -> (NBmodules + First DG-ID)
     uint32 dgids32 = 0x00000004;
     uint32 mask32  = 0x00000400;
     // modules 10->31
-    for ( int i = 0; i < (int)(MIN(NB_OF_MODULES,22)); i++ )
+    for ( int i = 10; i < 32; i++ )
     {
-        dgids32 |= mask32;
+        if (i >= FIRST_DG_ID && i < FIRST_DG_ID + NB_OF_MODULES) {
+            dgids32 |= mask32;
+            std::cout << "IMRS opening DG-ID " << i << std::endl;
+        }
         mask32 = mask32 << 1;
     }
     Buffer->Append(LOBYTE(LOWORD(dgids32)));
@@ -675,9 +678,12 @@ void CImrsProtocol::EncodePongPacket(CBuffer *Buffer) const
     // module 32->35
     uint8 dgids8 = 0x00;
     uint8 mask8 = 0x01;
-    for ( int i = 22; i < NB_OF_MODULES; i++ )
+    for ( int i = 32; i < 36; i++ )
     {
-        dgids8 |= mask8;
+        if (i >= FIRST_DG_ID && i < FIRST_DG_ID + NB_OF_MODULES) {
+            dgids8 |= mask8;
+            std::cout << "IMRS opening DG-ID " << i << std::endl; 
+        }
         mask8 = mask8 << 1;
     }
     Buffer->Append(dgids8);

--- a/src/cysfprotocol.cpp
+++ b/src/cysfprotocol.cpp
@@ -477,10 +477,10 @@ bool CYsfProtocol::IsValidDvHeaderPacket(const CIp &Ip, const CYSFFICH &Fich, co
             rpt1.SetModule(YSF_MODULE_ID);
             CCallsign rpt2 = m_ReflectorCallsign;
 
-            if ( (Fich.getSQ() >= 10) && (Fich.getSQ() < 10+NB_OF_MODULES) )
+            if ( (Fich.getSQ() >= FIRST_DG_ID) && (Fich.getSQ() < FIRST_DG_ID+NB_OF_MODULES) )
             {
                 // set module based on DG-ID value
-                rpt2.SetModule( 'A' + (char)(Fich.getSQ() - 10) );
+                rpt2.SetModule( 'A' + (char)(Fich.getSQ() - FIRST_DG_ID) );
             }
             else
             {

--- a/src/main.h
+++ b/src/main.h
@@ -127,6 +127,7 @@
 #define YSF_DEFAULT_NODE_RX_FREQ        437000000                           // in Hz
 #define YSF_AUTOLINK_ENABLE             0                                   // 1 = enable, 0 = disable auto-link
 #define YSF_AUTOLINK_MODULE             'B'                                 // module for client to auto-link to
+#define FIRST_DG_ID                     24
 
 // G3 Terminal
 #define G3_PRESENCE_PORT                12346                               // UDP port


### PR DESCRIPTION
I'm opening this draft PR to get feedbacks on this feature.

We tried setting the first DG-ID to 24 and connecting a DR-2 via IMRS. 
As you can see in the screen below the IDs 10-17 still appear to be connected. The 31 is open because we set the default module to H.
![image](https://user-images.githubusercontent.com/6943395/188931473-e430a57f-e015-4ef9-9853-1dc3381bdecc.png)

Any insight on what's missing?