### PR TITLE
make ambed more robust to handle device errors

### DIFF
--- a/ambed/cusb3xxxinterface.h
+++ b/ambed/cusb3xxxinterface.h
@@ -32,6 +32,7 @@
 #include "cambepacket.h"
 #include "cvoicepacket.h"
 #include "cvocodecinterface.h"
+#include "ctimepoint.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // define
@@ -104,6 +105,7 @@ protected:
     bool DisableParity(void);
     virtual bool ConfigureDevice(void)                      { return false; }
     bool ConfigureChannel(uint8, const uint8 *, int, int);
+    bool CheckIfDeviceNeedsReOpen(void);
     virtual int GetDeviceFifoSize(void) const              { return 1; }
     
     // io level
@@ -130,6 +132,8 @@ protected:
     CPacketQueue                m_DeviceQueue;
     int                         m_iSpeechFifolLevel;
     int                         m_iChannelFifolLevel;
+    CTimePoint                  m_SpeechFifoLevelTimeout;
+    CTimePoint                  m_ChannelFifoLevelTimeout;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch improves ambed to be able to handle and recover from device communication errors/timeouts.

Before this patch, when ambed failed to get reply from a device for some packet (1 or 2 depending of device fifo size...) then such device would not be usable anymore until restarting ambed (because ​m_iSpeechFifolLevel or m_iChannelFifolLevel vars would never decrement), the patch implements a timeout to restart these and a check to verify if the device is unresponsive, if yes then close and reopen/reinitialize the device. These problems are very frequent on some systems like Raspberry Pi requiring ambed to be restarted from time to time.

I did also include code to drop lagged packets on device queue after channel is closed, these lagged packets can accumulate if device have performance issues (like simultaneously using all channels full-duplex on DVStick33) or if some "weird" client on XLX sends excessive dv frames for some reason... it makes no sense to continue processing them after channel closed, and actually if same channel gets open again for other stream we need it free and not still processing lagged packets... This also solves the frequent "Unexpected transcoded packet received from ambed" seen on XLX log ( https://github.com/LX3JL/xlxd/issues/207 ), these unexpected packets actually belong to previous streams, these are usually retained (1 or 2 packets) waiting enough packets to fill fifo before restarting communication with device or lagged packets.