### PR TITLE
fix occasional ambed crash when device fails init

### DIFF
--- a/ambed/cusb3xxxinterface.cpp
+++ b/ambed/cusb3xxxinterface.cpp
@@ -52,6 +52,15 @@ CUsb3xxxInterface::CUsb3xxxInterface(uint32 uiVid, uint32 uiPid, const char *szD
 
 CUsb3xxxInterface::~CUsb3xxxInterface()
 {
+    // stop thread first
+    m_bStopThread = true;
+    if ( m_pThread != NULL )
+    {
+        m_pThread->join();
+        delete m_pThread;
+        m_pThread = NULL;
+    }
+    
     // delete m_SpeechQueues
     for ( int i = 0; i < m_SpeechQueues.size(); i++ )
     {


### PR DESCRIPTION
This patch fixes an occasional/random ambed crash (showing "Illegal instruction" error) that happens sometimes when some device interface fails Init(), when such happens interface instance is destroyed, for example at: https://github.com/LX3JL/xlxd/blob/adec5c8d14855136c702780723af4263d51edfe9/ambed/cftdidevicedescr.cpp#L397 and the issue is that queues are destroyed on CUsb3xxxInterface destructor while thread still running (thread is only stopped on destructor of parent class CVocodecInterface, last thing to happen), then the crash seems caused by eventual accesses to destroyed queues from that still running thread... solution is to stop thread first...