### PR TITLE
cg3protocol: fix crash/default initialize std::thread pointers

### DIFF
--- a/src/cg3protocol.h
+++ b/src/cg3protocol.h
@@ -64,7 +64,13 @@ class CG3Protocol : public CProtocol
 {
 public:
     // constructor
-    CG3Protocol() : m_GwAddress(0u), m_Modules("*"), m_LastModTime(0) {};
+    CG3Protocol() :
+        m_GwAddress(0u),
+        m_Modules("*"),
+        m_LastModTime(0),
+        m_pPresenceThread(nullptr),
+        m_pConfigThread(nullptr),
+        m_pIcmpThread(nullptr) {}
     
     // destructor
     virtual ~CG3Protocol() {};


### PR DESCRIPTION
During testing in a sandbox environment, xlxd crashed in `CG3Protocol::Close()`. The root cause was dereferencing `m_pPresenceThread` when the object had never been initialized. In this case an error occured during `::Init()` which set `ok=false`, so the initialization of the threads was skipped.

This commit also resolves an issue where all 3 worker threads were being assigned to `m_pPresenceThread` during `std::thread` creation.

This commit does 5 things:

(1) Default initializes the thread pointers to avoid the crash.
(2) Fixes an issue where all three worker threads were initialized to the same variable.
(3) Wraps the thread allocation with `try`/`catch` since `std::thread` can throw.
(4) Does some light cleaning in `::Close`, e.g., converting `NULL` to `nullptr`.
(5) Resolves a compilation issue where a `NULL` was being returned from a function defined `bool`.