### PR TITLE
isdigit() may return any non-zero result for success

### DIFF
--- a/src/cdmriddir.cpp
+++ b/src/cdmriddir.cpp
@@ -152,7 +152,7 @@ bool CDmridDir::IsValidDmrid(const char *sz)
         ok = true;
         for ( size_t i = 0; (i < n) && ok; i++ )
         {
-            ok &= ::isdigit(sz[i]);
+            ok = ::isdigit(sz[i]);
         }
     }
     return ok;


### PR DESCRIPTION
POSIX states that the return value of `isdigit()`: 

> shall return non-zero if c is a decimal digit; otherwise, they shall return 0.

Thus the form:

  `ok &= isdigit(x)`

is invalid since the runtime is not required to return 1.

This bug was observed on Debian 11 while using the clang toolchain. In that environment, `isdigit()` returns 2048 for a positive match.