### PR TITLE
CDmridDir destructor should be virtual

### DIFF
--- a/src/cdmriddir.h
+++ b/src/cdmriddir.h
@@ -50,7 +50,7 @@ public:
     CDmridDir();
     
     // destructor
-    ~CDmridDir();
+    virtual ~CDmridDir();
     
     // init & close
     virtual bool Init(void);


### PR DESCRIPTION
`CDmridDir` is a base class for `CDmridDirHttp` and `CDmridDirFile`, so its destructor should be marked virtual to prevent undefined behavior. This problem is not currently exposed because the program uses `#ifdef` semantics to create direct instantiations of derived classes in `main.h`:

```c
#if (DMRIDDB_USE_RLX_SERVER == 1)
    class CDmridDirHttp;
    extern CDmridDirHttp   g_DmridDir;
#else
    class CDmridDirFile;
    extern CDmridDirFile   g_DmridDir;
#endif
```