### PR TITLE
Improve shutdown behavior (enable clean shutdowns)

### DIFF
--- a/src/ccodecstream.h
+++ b/src/ccodecstream.h
@@ -97,7 +97,7 @@ protected:
     CPacketQueue    m_LocalQueue;
 
     // thread
-    bool            m_bStopThread;
+    std::atomic_bool m_bStopThread;
     std::thread     *m_pThread;
     CTimePoint      m_TimeoutTimer;
     CTimePoint      m_StatsTimer;

--- a/src/cdmriddir.h
+++ b/src/cdmriddir.h
@@ -31,6 +31,7 @@
 #include <netdb.h>
 #include "cbuffer.h"
 #include "ccallsign.h"
+#include "csimplecondition.h"
 
 // compare function for std::map::find
 
@@ -84,9 +85,10 @@ protected:
     
     // Lock()
     std::mutex          m_Mutex;
+    CSimpleCondition    m_cv;
            
     // thread
-    bool                m_bStopThread;
+    std::atomic_bool    m_bStopThread;
     std::thread         *m_pThread;
 
 };

--- a/src/cg3protocol.cpp
+++ b/src/cg3protocol.cpp
@@ -80,8 +80,8 @@ bool CG3Protocol::Init(void)
     {
         // start helper threads
         m_pPresenceThread = new std::thread(PresenceThread, this);
-        m_pPresenceThread = new std::thread(ConfigThread, this);
-        m_pPresenceThread = new std::thread(IcmpThread, this);
+        m_pConfigThread = new std::thread(ConfigThread, this);
+        m_pIcmpThread = new std::thread(IcmpThread, this);
     }
 #endif
     
@@ -94,6 +94,7 @@ bool CG3Protocol::Init(void)
 
 void CG3Protocol::Close(void)
 {
+    m_bStopThread = true;
     if (m_pPresenceThread != NULL)
     {
         m_pPresenceThread->join();

--- a/src/cg3protocol.h
+++ b/src/cg3protocol.h
@@ -64,7 +64,13 @@ class CG3Protocol : public CProtocol
 {
 public:
     // constructor
-    CG3Protocol() : m_GwAddress(0u), m_Modules("*"), m_LastModTime(0) {};
+    CG3Protocol() :
+        m_pPresenceThread(nullptr),
+        m_pConfigThread(nullptr),
+        m_pIcmpThread(nullptr),
+        m_GwAddress(0u),
+        m_Modules("*"),
+        m_LastModTime(0) {}
     
     // destructor
     virtual ~CG3Protocol() {};

--- a/src/cgatekeeper.h
+++ b/src/cgatekeeper.h
@@ -30,6 +30,7 @@
 #include "cip.h"
 #include "ccallsignlist.h"
 #include "cpeercallsignlist.h"
+#include "csimplecondition.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // class
@@ -71,8 +72,10 @@ protected:
     CPeerCallsignList   m_PeerList;
     
     // thread
-    bool                m_bStopThread;
+    CSimpleCondition    m_cv;
+    std::atomic_bool    m_bStopThread;
     std::thread         *m_pThread;
+
 };
 
 

--- a/src/cprotocol.h
+++ b/src/cprotocol.h
@@ -132,7 +132,7 @@ protected:
     CPacketQueue    m_Queue;
     
     // thread
-    bool            m_bStopThread;
+    std::atomic_bool m_bStopThread;
     std::thread     *m_pThread;
     
     // identity

--- a/src/creflector.h
+++ b/src/creflector.h
@@ -31,6 +31,8 @@
 #include "cprotocols.h"
 #include "cpacketstream.h"
 #include "cnotificationqueue.h"
+#include "cysfnodedir.h"
+#include "csimplecondition.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -137,7 +139,8 @@ protected:
     std::array<CPacketStream, NB_OF_MODULES> m_Streams;
     
     // threads
-    bool            m_bStopThreads;
+    CSimpleCondition        m_cv;
+    std::atomic_bool        m_bStopThreads;
     std::array<std::thread *, NB_OF_MODULES> m_RouterThreads;
     std::thread    *m_XmlReportThread;
     std::thread    *m_JsonReportThread;

--- a/src/csimplecondition.h
+++ b/src/csimplecondition.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+class CSimpleCondition final
+{
+public:
+    CSimpleCondition() : m_Mutex(), m_Condition() {}
+    CSimpleCondition(const CSimpleCondition&) = delete;
+    CSimpleCondition& operator=(const CSimpleCondition&) = delete;
+    CSimpleCondition(CSimpleCondition&&) = delete;
+    ~CSimpleCondition() {};
+
+    // Wait up to @duration to be signaled, or until @predicate is true.
+    // Returns result of predicate after timing out or being signaled.
+    template<typename Duration, typename Predicate>
+    bool wait(Duration, Predicate);
+
+    // Signal waiters. If @all is true, all waiters will be woken up.
+    void signal(bool all=true)
+    {
+        if (all)
+            m_Condition.notify_all();
+        else
+            m_Condition.notify_one();
+    }
+
+private:
+    std::mutex m_Mutex;
+    std::condition_variable m_Condition;
+};
+
+// Note: @timeout is a relative duration, e.g., "30s".
+template<typename Duration, typename Predicate>
+bool CSimpleCondition::wait(Duration timeout, Predicate predicate)
+{
+    std::unique_lock<std::mutex> lock(m_Mutex);
+    auto bound = std::chrono::system_clock::now() + timeout;
+    return m_Condition.wait_until(lock, bound, predicate); 
+}

--- a/src/ctranscoder.h
+++ b/src/ctranscoder.h
@@ -92,7 +92,7 @@ protected:
     uint16          m_PortOpenStream;
     
     // thread
-    bool            m_bStopThread;
+    std::atomic_bool  m_bStopThread;
     std::thread     *m_pThread;
 
     // socket

--- a/src/cwiresxcmdhandler.h
+++ b/src/cwiresxcmdhandler.h
@@ -86,7 +86,7 @@ protected:
     CWiresxPacketQueue m_PacketQueue;
     
     // thread
-    bool               m_bStopThread;
+    std::atomic_bool   m_bStopThread;
     std::thread        *m_pThread;
 };
 

--- a/src/cysfnodedir.h
+++ b/src/cysfnodedir.h
@@ -32,6 +32,7 @@
 #include "cbuffer.h"
 #include "ccallsign.h"
 #include "cysfnode.h"
+#include "csimplecondition.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // define
@@ -84,9 +85,10 @@ protected:
 protected:
     // Lock()
      std::mutex          m_Mutex;
-            
+
      // thread
-     bool                m_bStopThread;
+     CSimpleCondition    m_cv;
+     std::atomic_bool    m_bStopThread;
      std::thread         *m_pThread;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include "creflector.h"
 
 #include "syslog.h"
+#include <csignal>
 #include <sys/stat.h>
 
 
@@ -38,6 +39,37 @@ CReflector  g_Reflector;
 // function declaration
 
 #include "cusers.h"
+
+// Returns caught termination signal or -1 on error
+static int wait_for_termination()
+{
+    sigset_t waitset;
+    siginfo_t siginfo;
+
+    sigemptyset(&waitset);
+    sigaddset(&waitset, SIGTERM);
+    sigaddset(&waitset, SIGINT);
+    sigaddset(&waitset, SIGQUIT);
+    sigaddset(&waitset, SIGHUP);
+    pthread_sigmask(SIG_BLOCK, &waitset, nullptr);
+
+    // Now wait for termination signal
+    int result = -1;
+    while (result < 0)
+    {
+        result = sigwaitinfo(&waitset, &siginfo);
+        if (result == -1 && errno == EINTR)
+        {
+            // try again
+            if (errno == EINTR)
+                continue;
+
+            // an unexpected error occurred, consider it fatal
+            break;
+        }
+    }
+    return result;
+}
 
 int main(int argc, const char * argv[])
 {
@@ -101,37 +133,30 @@ int main(int argc, const char * argv[])
     g_Reflector.SetCallsign(argv[1]);
     g_Reflector.SetListenIp(CIp(argv[2]));
     g_Reflector.SetTranscoderIp(CIp(CIp(argv[3])));
-  
+
+    // Block all signals while starting up the reflector -- we don't
+    // want any of the worker threads handling them.
+    sigset_t sigblockall, sigorig;
+    sigfillset(&sigblockall);
+    pthread_sigmask(SIG_SETMASK, &sigblockall, &sigorig);
+
     // and let it run
     if ( !g_Reflector.Start() )
     {
         std::cout << "Error starting reflector" << std::endl;
         exit(EXIT_FAILURE);
     }
+
+    // Restore main thread default signal state
+    pthread_sigmask(SIG_SETMASK, &sigorig, nullptr);
+
     std::cout << "Reflector " << g_Reflector.GetCallsign()
               << "started and listening on " << g_Reflector.GetListenIp() << std::endl;
     
-#ifdef RUN_AS_DAEMON
-	// run forever
-    while ( true )
-    {
-        // sleep 60 seconds
-        CTimePoint::TaskSleepFor(60000);
-    }
-#else
-    // wait any key
-    for (;;)
-    {
-        // sleep 60 seconds
-        CTimePoint::TaskSleepFor(60000);
-#ifdef DEBUG_DUMPFILE
-        g_Reflector.m_DebugFile.close();
-#endif
-    }
-#endif
-    
     // and wait for end
-    g_Reflector.Stop();
+    wait_for_termination();
+
+    g_Reflector->Stop();
     std::cout << "Reflector stopped" << std::endl;
     
     // done

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ static int wait_for_termination()
     sigaddset(&waitset, SIGHUP);
     pthread_sigmask(SIG_BLOCK, &waitset, nullptr);
 
-    // Now wait for termination signal
+    // Wait for a termination signal
     int result = -1;
     while (result < 0)
     {
@@ -156,7 +156,7 @@ int main(int argc, const char * argv[])
     // and wait for end
     wait_for_termination();
 
-    g_Reflector->Stop();
+    g_Reflector.Stop();
     std::cout << "Reflector stopped" << std::endl;
     
     // done


### PR DESCRIPTION
The two commits in this PR have their own commentary describing the changes that can be referred to, but to quickly summarize, this PR enables clean shutdowns of the reflector. The current code has no way of performing a clean shutdown for a couple reasons: (1) infinite loops in main() and (2) long blocking sleeps in various worker threads. 

The general approach was to swap the blocking sleeps with condition variables that are signaled during shutdown, and to add signal handling in the main thread for termination signals. With these changes the reflector shuts down cleanly in less than a second with run as a daemon or in the foreground (when in the foreground, CTRL-C will initiate the shutdown).