### PR TITLE
fix dashboard intermittently showing repeated callsigns on some servers

### DIFF
--- a/dashboard/pgs/functions.php
+++ b/dashboard/pgs/functions.php
@@ -52,7 +52,6 @@ function FormatSeconds($seconds) {
 
 function CreateCode ($laenge) {   
 	$zeichen = "1234567890abcdefghijklmnopqrstuvwyxzABCDEFGHIJKLMNAOPQRSTUVWYXZ";   
-	mt_srand( (double) microtime() * 1000000); 
 	$out = "";
 	for ($i=1;$i<=$laenge;$i++){ 
 		$out .= $zeichen[mt_rand(0,(strlen($zeichen)-1))];       

--- a/dashboard2/pgs/functions.php
+++ b/dashboard2/pgs/functions.php
@@ -52,7 +52,6 @@ function FormatSeconds($seconds) {
 
 function CreateCode ($laenge) {   
 	$zeichen = "1234567890abcdefghijklmnopqrstuvwyxzABCDEFGHIJKLMNAOPQRSTUVWYXZ";   
-	mt_srand( (double) microtime() * 1000000); 
 	$out = "";
 	for ($i=1;$i<=$laenge;$i++){ 
 		$out .= $zeichen[mt_rand(0,(strlen($zeichen)-1))];       


### PR DESCRIPTION
N0AD asked me for help with a strange issue he was experiencing on his XLX720 with dashboard intermittently (on refreshes) showing repeated callsigns (i.e showing the same callsign for every/most node connected) on his server, conclusion:

_"After looking at code I think I understand now how it happens, actually I'm surprised why it doesn't happen on my/other servers... if my suspect is correct the problem must be timing triggered. When generating internal random ids for nodes, random generator is being initialized for each node (bad idea) using microtime() value as seed, and... probably your server is either very fast or hardware system timer is low resolution, or code is much optimized on that php version... something is probably causing random generator to be initialized on your server multiple times to the same exact seed, causing all nodes to get the same id..._

_I think it's not correct at all that the random generator is being initialized multiple times... and actually according to php documentation it's not even required to do it at all (it's done automatically since php 4.2 for each script instance), manually initializing random generator should be done only if we really want to initialize it to a specific seed to generate a sequence of predictable pseudo-random values according to the specified seed, not the case..."_

I think it's ok to just remove mt_srand lines completely (instead of changing them to do it only once), because surely no one will run dashboard on php older than 4.2 (and most probably it would not even work due to other parts of code). XLX720 is now running with this change and the problem isn't happening anymore.