### PR TITLE
allow pass dmr/ysf to peers, without transcoding

### DIFF
--- a/src/cxlxprotocol.cpp
+++ b/src/cxlxprotocol.cpp
@@ -287,14 +287,7 @@ void CXlxProtocol::HandleQueue(void)
                                 break;
                             case XLX_PROTOCOL_REVISION_2:
                             default:
-                                if ( g_Transcoder.IsConnected() )
-                                {
-                                    m_Socket.Send(buffer, client->GetIp());
-                                }
-                                else
-                                {
-                                    m_Socket.Send(bufferLegacy, client->GetIp());
-                                }
+                                m_Socket.Send(buffer, client->GetIp());
                                 break;
                         }
                     }


### PR DESCRIPTION
In the original code when no transcoder connected (i.e. xlxd not connected to ambed) streams to xlx peers downgrade to using rev1 xlx protocol dv packets (dstar only ambe, no dmr/ysf) despite connected to rev2 peer... then dmr/ysf voice only really pass through xlx peers (incl. BM) when transcoder is connected. I see no reason and no sense for this downgrade when no transcoder connected, as reflector may be used for just dmr/ysf and these should obviously pass to peers!? After this patch it will always use rev2 packets on interlinks to rev2 peers (rev1 packets will still be used to rev1 peers).

Problem discussed at: https://xlxbbs.epf.lu/viewtopic.php?p=2871