### PR TITLE
set eot status bit for ysf last packet

### DIFF
--- a/src/cysfprotocol.cpp
+++ b/src/cysfprotocol.cpp
@@ -803,8 +803,8 @@ bool CYsfProtocol::EncodeDvLastPacket(const CDvHeaderPacket &Header, CBuffer *Bu
     Buffer->Append((uint8 *)sz, YSF_CALLSIGN_LENGTH);
     // dest
     Buffer->Append(dest, 10);
-    // net frame counter
-    Buffer->Append((uint8)0x00);
+    // eot status bit + net frame counter (<<1)
+    Buffer->Append((uint8)0x01);
     // FS
     Buffer->Append((uint8 *)YSF_SYNC_BYTES, YSF_SYNC_LENGTH_BYTES);
     // FICH


### PR DESCRIPTION
I can't find real documentation about YSF protocol, however I did look at G4KLX code, like MMDVMHost, and I see he always set and rely on this bit to identify EOT:
https://github.com/g4klx/MMDVMHost/blob/f02cbcb141e53f1aeac5d0b6ee6dfc9d3b6e2b61/YSFControl.cpp#L915

MMDVMHost RX from XLX without the patch:
```
M: 2023-12-08 03:08:42.585 YSF, received network data from CT2HRB to DG-ID 0 at CT2HRB
M: 2023-12-08 03:08:45.345 YSF, network watchdog has expired, 1.4 seconds, 0% packet loss, BER: 0.0%
M: 2023-12-08 03:08:47.312 YSF, received network data from CT2HRB to DG-ID 0 at CT2HRB
M: 2023-12-08 03:08:50.628 YSF, network watchdog has expired, 1.9 seconds, 0% packet loss, BER: 0.0%
```
MMDVMHost RX from XLX after the patch:
```
M: 2023-12-08 03:30:18.097 YSF, received network data from CT2HRB to DG-ID 0 at CT2HRB
M: 2023-12-08 03:30:19.609 YSF, received network end of transmission from CT2HRB to DG-ID 0, 1.6 seconds, 0% packet loss, BER: 0.0%
M: 2023-12-08 03:30:23.130 YSF, received network data from CT2HRB to DG-ID 0 at CT2HRB
M: 2023-12-08 03:30:25.028 YSF, received network end of transmission from CT2HRB to DG-ID 0, 2.0 seconds, 0% packet loss, BER: 0.0%
```
